### PR TITLE
add community voting for campaign verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Rust build artifacts
+/target/
+
+# Cargo lockfile (typically not committed for library crates/contracts)
+Cargo.lock
+
+# Soroban test snapshots
+/test_snapshots/
+
+# macOS and editor local files
+.DS_Store
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "20.1.0"
+soroban-sdk = "=20.1.0"
 
 [dev-dependencies]
-soroban-sdk = { version = "20.1.0", features = ["testutils"] }
+soroban-sdk = { version = "=20.1.0", features = ["testutils"] }
+derive_arbitrary = "=1.3.2"
 
 [profile.release]
 opt-level = "z"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ pub enum Error {
     NoFundsToWithdraw = 13,
     CampaignAlreadyVerified = 14,
     ValidationFailed = 15,
+    AlreadyVoted = 16,
+    NotTokenHolder = 17,
+    VotingQuorumNotMet = 18,
+    VotingThresholdNotMet = 19,
 }
 
 #[contracttype]
@@ -57,16 +61,24 @@ pub struct Campaign {
 pub enum DataKey {
     Admin,
     Token,
-    PlatformFee, 
+    PlatformFee,
     CampaignCount,
     Campaign(u32),
     Contribution(u32, Address),
     RevenuePool(u32),
     RevenueClaimed(u32, Address),
+    ApproveVotes(u32),
+    RejectVotes(u32),
+    HasVoted(u32, Address),
+    MinVotesQuorum,
+    ApprovalThresholdBps,
 }
 
 #[contract]
 pub struct ProofOfHeart;
+
+const DEFAULT_MIN_VOTES_QUORUM: u32 = 3;
+const DEFAULT_APPROVAL_THRESHOLD_BPS: u32 = 6000;
 
 #[contractimpl]
 impl ProofOfHeart {
@@ -74,10 +86,16 @@ impl ProofOfHeart {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
-        
+
         let valid_fee = if platform_fee > 1000 { 1000 } else { platform_fee }; // Max 10% limit
         env.storage().instance().set(&DataKey::PlatformFee, &valid_fee);
         env.storage().instance().set(&DataKey::CampaignCount, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinVotesQuorum, &DEFAULT_MIN_VOTES_QUORUM);
+        env.storage()
+            .instance()
+            .set(&DataKey::ApprovalThresholdBps, &DEFAULT_APPROVAL_THRESHOLD_BPS);
     }
 
     pub fn create_campaign(
@@ -294,6 +312,135 @@ impl ProofOfHeart {
         Ok(())
     }
 
+    pub fn set_voting_params(
+        env: Env,
+        admin: Address,
+        min_votes_quorum: u32,
+        approval_threshold_bps: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(Error::NotAuthorized);
+        }
+
+        if min_votes_quorum == 0 || approval_threshold_bps == 0 || approval_threshold_bps > 10000 {
+            return Err(Error::ValidationFailed);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MinVotesQuorum, &min_votes_quorum);
+        env.storage()
+            .instance()
+            .set(&DataKey::ApprovalThresholdBps, &approval_threshold_bps);
+
+        Ok(())
+    }
+
+    pub fn vote_on_campaign(
+        env: Env,
+        campaign_id: u32,
+        voter: Address,
+        approve: bool,
+    ) -> Result<(), Error> {
+        voter.require_auth();
+
+        let campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
+
+        if campaign.is_verified {
+            return Err(Error::CampaignAlreadyVerified);
+        }
+        if campaign.is_cancelled || !campaign.is_active {
+            return Err(Error::CampaignNotActive);
+        }
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_client = token::Client::new(&env, &token_addr);
+        let voter_balance = token_client.balance(&voter);
+        if voter_balance <= 0 {
+            return Err(Error::NotTokenHolder);
+        }
+
+        let has_voted_key = DataKey::HasVoted(campaign_id, voter.clone());
+        let has_voted: bool = env.storage().instance().get(&has_voted_key).unwrap_or(false);
+        if has_voted {
+            return Err(Error::AlreadyVoted);
+        }
+
+        if approve {
+            let key = DataKey::ApproveVotes(campaign_id);
+            let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
+            env.storage().instance().set(&key, &(current + 1));
+        } else {
+            let key = DataKey::RejectVotes(campaign_id);
+            let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
+            env.storage().instance().set(&key, &(current + 1));
+        }
+
+        env.storage().instance().set(&has_voted_key, &true);
+        env.events()
+            .publish(("campaign_vote_cast", campaign_id, voter), approve);
+
+        Ok(())
+    }
+
+    pub fn verify_campaign(env: Env, campaign_id: u32) -> Result<(), Error> {
+        let mut campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
+
+        if campaign.is_verified {
+            return Err(Error::CampaignAlreadyVerified);
+        }
+
+        let approve_votes: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ApproveVotes(campaign_id))
+            .unwrap_or(0);
+        let reject_votes: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RejectVotes(campaign_id))
+            .unwrap_or(0);
+        let total_votes = approve_votes + reject_votes;
+
+        let min_votes_quorum: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinVotesQuorum)
+            .unwrap_or(DEFAULT_MIN_VOTES_QUORUM);
+        if total_votes < min_votes_quorum {
+            return Err(Error::VotingQuorumNotMet);
+        }
+
+        let approval_threshold_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ApprovalThresholdBps)
+            .unwrap_or(DEFAULT_APPROVAL_THRESHOLD_BPS);
+        let approval_bps = (approve_votes * 10000) / total_votes;
+        if approval_bps < approval_threshold_bps {
+            return Err(Error::VotingThresholdNotMet);
+        }
+
+        campaign.is_verified = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Campaign(campaign_id), &campaign);
+        env.events()
+            .publish(("campaign_verified", campaign_id), approve_votes);
+
+        Ok(())
+    }
+
     pub fn get_campaign(env: Env, campaign_id: u32) -> Campaign {
         env.storage().instance().get(&DataKey::Campaign(campaign_id)).unwrap()
     }
@@ -308,6 +455,41 @@ impl ProofOfHeart {
 
     pub fn get_revenue_claimed(env: Env, campaign_id: u32, contributor: Address) -> i128 {
         env.storage().instance().get(&DataKey::RevenueClaimed(campaign_id, contributor)).unwrap_or(0)
+    }
+
+    pub fn get_approve_votes(env: Env, campaign_id: u32) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ApproveVotes(campaign_id))
+            .unwrap_or(0)
+    }
+
+    pub fn get_reject_votes(env: Env, campaign_id: u32) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::RejectVotes(campaign_id))
+            .unwrap_or(0)
+    }
+
+    pub fn has_voted(env: Env, campaign_id: u32, voter: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::HasVoted(campaign_id, voter))
+            .unwrap_or(false)
+    }
+
+    pub fn get_min_votes_quorum(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinVotesQuorum)
+            .unwrap_or(DEFAULT_MIN_VOTES_QUORUM)
+    }
+
+    pub fn get_approval_threshold_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ApprovalThresholdBps)
+            .unwrap_or(DEFAULT_APPROVAL_THRESHOLD_BPS)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -174,3 +174,92 @@ fn test_failure_states() {
     client.claim_refund(&campaign_id, &contributor1);
     assert_eq!(token.balance(&contributor1), 5000);
 }
+
+#[test]
+fn test_community_voting_verification_success() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) = setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let title = String::from_str(&env, "Community Verified");
+    let desc = String::from_str(&env, "Verify by voting");
+    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Educator, &false, &0);
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &false);
+
+    assert_eq!(client.get_approve_votes(&campaign_id), 2);
+    assert_eq!(client.get_reject_votes(&campaign_id), 1);
+    assert_eq!(client.has_voted(&campaign_id, &contributor1), true);
+
+    client.verify_campaign(&campaign_id);
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.is_verified, true);
+}
+
+#[test]
+fn test_vote_prevents_double_voting_and_requires_token_holder() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    let non_holder = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+
+    let title = String::from_str(&env, "Vote Safety");
+    let desc = String::from_str(&env, "No duplicate votes");
+    let campaign_id = client.create_campaign(&creator, &title, &desc, &500, &30, &Category::Learner, &false, &0);
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &false);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyVoted);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &non_holder, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotTokenHolder);
+}
+
+#[test]
+fn test_verify_campaign_quorum_and_threshold_edges() {
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) = setup_env();
+    let voter3 = Address::generate(&env);
+    let voter4 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+    token_admin.mint(&voter4, &100);
+
+    client.set_voting_params(&admin, &4, &7500);
+    assert_eq!(client.get_min_votes_quorum(), 4);
+    assert_eq!(client.get_approval_threshold_bps(), 7500);
+
+    let title1 = String::from_str(&env, "Quorum Campaign");
+    let desc1 = String::from_str(&env, "Needs 4 votes");
+    let campaign_id_1 = client.create_campaign(&creator, &title1, &desc1, &700, &30, &Category::Publisher, &false, &0);
+
+    client.vote_on_campaign(&campaign_id_1, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id_1, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id_1, &voter3, &true);
+
+    let res = client.try_verify_campaign(&campaign_id_1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingQuorumNotMet);
+
+    client.vote_on_campaign(&campaign_id_1, &voter4, &false);
+    client.verify_campaign(&campaign_id_1);
+    assert_eq!(client.get_campaign(&campaign_id_1).is_verified, true);
+
+    let title2 = String::from_str(&env, "Threshold Campaign");
+    let desc2 = String::from_str(&env, "Fails threshold");
+    let campaign_id_2 = client.create_campaign(&creator, &title2, &desc2, &700, &30, &Category::Publisher, &false, &0);
+
+    client.vote_on_campaign(&campaign_id_2, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id_2, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id_2, &voter3, &false);
+    client.vote_on_campaign(&campaign_id_2, &voter4, &false);
+
+    let res = client.try_verify_campaign(&campaign_id_2);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingThresholdNotMet);
+}


### PR DESCRIPTION
Closes #2 

- add vote_on_campaign to record approve/reject votes from token holders
- prevent duplicate voting with HasVoted tracking
- add verify_campaign with quorum + approval-threshold checks
- add admin-configurable voting params and read helpers
- add unit tests for success, double-vote prevention, quorum, and threshold edges
- add .gitignore for target/, test_snapshots/, Cargo.lock, and local editor files
