### PR TITLE
feat: add re-initialization guard and test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(unexpected_cfgs)]
 
 /// Current contract version. Increment this on each breaking upgrade.
 /// To upgrade a deployed Soroban contract, call `env.deployer().update_current_contract_wasm(new_wasm_hash)`
@@ -34,6 +35,7 @@ pub enum Error {
     NotTokenHolder = 17,
     VotingQuorumNotMet = 18,
     VotingThresholdNotMet = 19,
+    AlreadyInitialized = 20,
 }
 
 #[contracttype]
@@ -90,23 +92,37 @@ const DEFAULT_APPROVAL_THRESHOLD_BPS: u32 = 6000;
 
 #[contractimpl]
 impl ProofOfHeart {
-    pub fn init(env: Env, admin: Address, token: Address, platform_fee: u32) {
+    pub fn init(env: Env, admin: Address, token: Address, platform_fee: u32) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
 
-        let valid_fee = if platform_fee > 1000 { 1000 } else { platform_fee }; // Max 10% limit
-        env.storage().instance().set(&DataKey::PlatformFee, &valid_fee);
+        let valid_fee = if platform_fee > 1000 {
+            1000
+        } else {
+            platform_fee
+        }; // Max 10% limit
+        env.storage()
+            .instance()
+            .set(&DataKey::PlatformFee, &valid_fee);
         env.storage().instance().set(&DataKey::CampaignCount, &0u32);
-        env.storage().instance().set(&DataKey::Version, &CONTRACT_VERSION);
+        env.storage()
+            .instance()
+            .set(&DataKey::Version, &CONTRACT_VERSION);
         env.storage()
             .instance()
             .set(&DataKey::MinVotesQuorum, &DEFAULT_MIN_VOTES_QUORUM);
-        env.storage()
-            .instance()
-            .set(&DataKey::ApprovalThresholdBps, &DEFAULT_APPROVAL_THRESHOLD_BPS);
+        env.storage().instance().set(
+            &DataKey::ApprovalThresholdBps,
+            &DEFAULT_APPROVAL_THRESHOLD_BPS,
+        );
+        Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn create_campaign(
         env: Env,
         creator: Address,
@@ -120,20 +136,33 @@ impl ProofOfHeart {
     ) -> Result<u32, Error> {
         creator.require_auth();
 
-        if funding_goal <= 0 { return Err(Error::FundingGoalMustBePositive); }
-        if duration_days < 1 || duration_days > 365 { return Err(Error::InvalidDuration); }
-        if title.len() == 0 || title.len() > 100 { return Err(Error::ValidationFailed); }
-        if description.len() == 0 || description.len() > 1000 { return Err(Error::ValidationFailed); }
-        
+        if funding_goal <= 0 {
+            return Err(Error::FundingGoalMustBePositive);
+        }
+        if !(1..=365).contains(&duration_days) {
+            return Err(Error::InvalidDuration);
+        }
+        if title.len() == 0 || title.len() > 100 {
+            return Err(Error::ValidationFailed);
+        }
+        if description.len() == 0 || description.len() > 1000 {
+            return Err(Error::ValidationFailed);
+        }
+
         if category != Category::EducationalStartup && has_revenue_sharing {
             return Err(Error::RevenueShareOnlyForStartup);
         }
 
-        if has_revenue_sharing && (revenue_share_percentage == 0 || revenue_share_percentage > 5000) {
+        if has_revenue_sharing && (revenue_share_percentage == 0 || revenue_share_percentage > 5000)
+        {
             return Err(Error::InvalidRevenueShare);
         }
 
-        let mut count: u32 = env.storage().instance().get(&DataKey::CampaignCount).unwrap_or(0);
+        let mut count: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CampaignCount)
+            .unwrap_or(0);
         count += 1;
 
         let current_time = env.ledger().timestamp();
@@ -156,91 +185,153 @@ impl ProofOfHeart {
             revenue_share_percentage,
         };
 
-        env.storage().instance().set(&DataKey::Campaign(count), &campaign);
-        env.storage().instance().set(&DataKey::CampaignCount, &count);
-        env.storage().instance().set(&DataKey::RevenuePool(count), &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::Campaign(count), &campaign);
+        env.storage()
+            .instance()
+            .set(&DataKey::CampaignCount, &count);
+        env.storage()
+            .instance()
+            .set(&DataKey::RevenuePool(count), &0i128);
 
-        env.events().publish(("campaign_created", count, creator), title);
+        env.events()
+            .publish(("campaign_created", count, creator), title);
 
         Ok(count)
     }
 
-    pub fn contribute(env: Env, campaign_id: u32, contributor: Address, amount: i128) -> Result<(), Error> {
+    pub fn contribute(
+        env: Env,
+        campaign_id: u32,
+        contributor: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
         contributor.require_auth();
 
-        if amount <= 0 { return Err(Error::ContributionMustBePositive); }
+        if amount <= 0 {
+            return Err(Error::ContributionMustBePositive);
+        }
 
-        let mut campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
+        let mut campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
 
-        if !campaign.is_active || campaign.is_cancelled { return Err(Error::CampaignNotActive); }
-        if contributor == campaign.creator { return Err(Error::NotAuthorized); }
-        if env.ledger().timestamp() > campaign.deadline { return Err(Error::DeadlinePassed); }
+        if !campaign.is_active || campaign.is_cancelled {
+            return Err(Error::CampaignNotActive);
+        }
+        if contributor == campaign.creator {
+            return Err(Error::NotAuthorized);
+        }
+        if env.ledger().timestamp() > campaign.deadline {
+            return Err(Error::DeadlinePassed);
+        }
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&contributor, &env.current_contract_address(), &amount);
 
         campaign.amount_raised += amount;
-        env.storage().instance().set(&DataKey::Campaign(campaign_id), &campaign);
+        env.storage()
+            .instance()
+            .set(&DataKey::Campaign(campaign_id), &campaign);
 
         let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
-        let current_contribution: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
-        env.storage().instance().set(&contribution_key, &(current_contribution + amount));
+        let current_contribution: i128 =
+            env.storage().instance().get(&contribution_key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&contribution_key, &(current_contribution + amount));
 
-        env.events().publish(("contribution_made", campaign_id, contributor), amount);
+        env.events()
+            .publish(("contribution_made", campaign_id, contributor), amount);
 
         Ok(())
     }
 
     pub fn withdraw_funds(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let mut campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
+        let mut campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
 
         campaign.creator.require_auth();
 
-        if campaign.is_cancelled { return Err(Error::CampaignNotActive); }
-        if campaign.funds_withdrawn { return Err(Error::FundsAlreadyWithdrawn); }
-        if campaign.amount_raised == 0 { return Err(Error::NoFundsToWithdraw); }
-        
-        let time_remaining = env.ledger().timestamp() <= campaign.deadline;
-        if campaign.amount_raised < campaign.funding_goal {
-             if time_remaining {
-                 return Err(Error::FundingGoalNotReached);
-             } else {
-                 return Err(Error::CampaignNotActive); 
-             }
+        if campaign.is_cancelled {
+            return Err(Error::CampaignNotActive);
+        }
+        if campaign.funds_withdrawn {
+            return Err(Error::FundsAlreadyWithdrawn);
+        }
+        if campaign.amount_raised == 0 {
+            return Err(Error::NoFundsToWithdraw);
         }
 
-        let platform_fee: u32 = env.storage().instance().get(&DataKey::PlatformFee).unwrap_or(300);
+        let time_remaining = env.ledger().timestamp() <= campaign.deadline;
+        if campaign.amount_raised < campaign.funding_goal {
+            if time_remaining {
+                return Err(Error::FundingGoalNotReached);
+            } else {
+                return Err(Error::CampaignNotActive);
+            }
+        }
+
+        let platform_fee: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PlatformFee)
+            .unwrap_or(300);
         let fee_amount = (campaign.amount_raised * (platform_fee as i128)) / 10000;
         let creator_amount = campaign.amount_raised - fee_amount;
 
         campaign.funds_withdrawn = true;
         campaign.is_active = false;
-        env.storage().instance().set(&DataKey::Campaign(campaign_id), &campaign);
+        env.storage()
+            .instance()
+            .set(&DataKey::Campaign(campaign_id), &campaign);
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let admin_addr: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         let client = token::Client::new(&env, &token_addr);
 
         client.transfer(&env.current_contract_address(), &admin_addr, &fee_amount);
-        client.transfer(&env.current_contract_address(), &campaign.creator, &creator_amount);
+        client.transfer(
+            &env.current_contract_address(),
+            &campaign.creator,
+            &creator_amount,
+        );
 
-        env.events().publish(("withdrawal", campaign_id, campaign.creator.clone()), creator_amount);
+        env.events().publish(
+            ("withdrawal", campaign_id, campaign.creator.clone()),
+            creator_amount,
+        );
 
         Ok(())
     }
 
     pub fn cancel_campaign(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let mut campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
+        let mut campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
         campaign.creator.require_auth();
 
-        if campaign.funds_withdrawn { return Err(Error::ValidationFailed); } 
+        if campaign.funds_withdrawn {
+            return Err(Error::ValidationFailed);
+        }
 
         campaign.is_cancelled = true;
         campaign.is_active = false;
-        env.storage().instance().set(&DataKey::Campaign(campaign_id), &campaign);
+        env.storage()
+            .instance()
+            .set(&DataKey::Campaign(campaign_id), &campaign);
 
-        env.events().publish(("campaign_cancelled", campaign_id), ());
+        env.events()
+            .publish(("campaign_cancelled", campaign_id), ());
 
         Ok(())
     }
@@ -248,17 +339,24 @@ impl ProofOfHeart {
     pub fn claim_refund(env: Env, campaign_id: u32, contributor: Address) -> Result<(), Error> {
         contributor.require_auth();
 
-        let campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
+        let campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
 
-        let failed_due_to_goal = env.ledger().timestamp() > campaign.deadline && campaign.amount_raised < campaign.funding_goal;
-        
+        let failed_due_to_goal = env.ledger().timestamp() > campaign.deadline
+            && campaign.amount_raised < campaign.funding_goal;
+
         if !(campaign.is_cancelled || failed_due_to_goal) {
-            return Err(Error::ValidationFailed); 
+            return Err(Error::ValidationFailed);
         }
 
         let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
         let amount: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
-        if amount == 0 { return Err(Error::NoFundsToWithdraw); }
+        if amount == 0 {
+            return Err(Error::NoFundsToWithdraw);
+        }
 
         env.storage().instance().set(&contribution_key, &0i128);
 
@@ -266,40 +364,60 @@ impl ProofOfHeart {
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&env.current_contract_address(), &contributor, &amount);
 
-        env.events().publish(("refund_claimed", campaign_id, contributor), amount);
+        env.events()
+            .publish(("refund_claimed", campaign_id, contributor), amount);
 
         Ok(())
     }
 
     pub fn deposit_revenue(env: Env, campaign_id: u32, amount: i128) -> Result<(), Error> {
-        let campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
+        let campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
         campaign.creator.require_auth();
 
-        if amount <= 0 { return Err(Error::ValidationFailed); }
-        if !campaign.has_revenue_sharing { return Err(Error::ValidationFailed); }
+        if amount <= 0 {
+            return Err(Error::ValidationFailed);
+        }
+        if !campaign.has_revenue_sharing {
+            return Err(Error::ValidationFailed);
+        }
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
-        
+
         client.transfer(&campaign.creator, &env.current_contract_address(), &amount);
 
         let pool_key = DataKey::RevenuePool(campaign_id);
         let current_pool: i128 = env.storage().instance().get(&pool_key).unwrap_or(0);
-        env.storage().instance().set(&pool_key, &(current_pool + amount));
+        env.storage()
+            .instance()
+            .set(&pool_key, &(current_pool + amount));
 
-        env.events().publish(("revenue_deposited", campaign_id), amount);
+        env.events()
+            .publish(("revenue_deposited", campaign_id), amount);
 
         Ok(())
     }
 
     pub fn claim_revenue(env: Env, campaign_id: u32, contributor: Address) -> Result<(), Error> {
-        let campaign: Campaign = env.storage().instance().get(&DataKey::Campaign(campaign_id)).ok_or(Error::CampaignNotFound)?;
-        if !campaign.has_revenue_sharing { return Err(Error::ValidationFailed); }
+        let campaign: Campaign = env
+            .storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .ok_or(Error::CampaignNotFound)?;
+        if !campaign.has_revenue_sharing {
+            return Err(Error::ValidationFailed);
+        }
 
         let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
         let contribution: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
-        
-        if contribution == 0 { return Err(Error::ValidationFailed); }
+
+        if contribution == 0 {
+            return Err(Error::ValidationFailed);
+        }
 
         let pool_key = DataKey::RevenuePool(campaign_id);
         let total_pool: i128 = env.storage().instance().get(&pool_key).unwrap_or(0);
@@ -311,15 +429,20 @@ impl ProofOfHeart {
 
         let claimable = total_due_to_contributor - already_claimed;
 
-        if claimable <= 0 { return Err(Error::NoFundsToWithdraw); }
+        if claimable <= 0 {
+            return Err(Error::NoFundsToWithdraw);
+        }
 
-        env.storage().instance().set(&claimed_key, &(already_claimed + claimable));
+        env.storage()
+            .instance()
+            .set(&claimed_key, &(already_claimed + claimable));
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&env.current_contract_address(), &contributor, &claimable);
 
-        env.events().publish(("revenue_claimed", campaign_id, contributor), claimable);
+        env.events()
+            .publish(("revenue_claimed", campaign_id, contributor), claimable);
 
         Ok(())
     }
@@ -379,7 +502,11 @@ impl ProofOfHeart {
         }
 
         let has_voted_key = DataKey::HasVoted(campaign_id, voter.clone());
-        let has_voted: bool = env.storage().instance().get(&has_voted_key).unwrap_or(false);
+        let has_voted: bool = env
+            .storage()
+            .instance()
+            .get(&has_voted_key)
+            .unwrap_or(false);
         if has_voted {
             return Err(Error::AlreadyVoted);
         }
@@ -477,19 +604,31 @@ impl ProofOfHeart {
     }
 
     pub fn get_campaign(env: Env, campaign_id: u32) -> Campaign {
-        env.storage().instance().get(&DataKey::Campaign(campaign_id)).unwrap()
+        env.storage()
+            .instance()
+            .get(&DataKey::Campaign(campaign_id))
+            .unwrap()
     }
 
     pub fn get_contribution(env: Env, campaign_id: u32, contributor: Address) -> i128 {
-        env.storage().instance().get(&DataKey::Contribution(campaign_id, contributor)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::Contribution(campaign_id, contributor))
+            .unwrap_or(0)
     }
 
     pub fn get_revenue_pool(env: Env, campaign_id: u32) -> i128 {
-        env.storage().instance().get(&DataKey::RevenuePool(campaign_id)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::RevenuePool(campaign_id))
+            .unwrap_or(0)
     }
 
     pub fn get_revenue_claimed(env: Env, campaign_id: u32, contributor: Address) -> i128 {
-        env.storage().instance().get(&DataKey::RevenueClaimed(campaign_id, contributor)).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::RevenueClaimed(campaign_id, contributor))
+            .unwrap_or(0)
     }
 
     /// Returns the current contract version stored in instance storage.
@@ -502,8 +641,14 @@ impl ProofOfHeart {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
         let valid_fee = if new_fee > 1000 { 1000 } else { new_fee };
-        let old_fee: u32 = env.storage().instance().get(&DataKey::PlatformFee).unwrap_or(300);
-        env.storage().instance().set(&DataKey::PlatformFee, &valid_fee);
+        let old_fee: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PlatformFee)
+            .unwrap_or(300);
+        env.storage()
+            .instance()
+            .set(&DataKey::PlatformFee, &valid_fee);
         env.events().publish(("fee_updated",), (old_fee, valid_fee));
         Ok(())
     }
@@ -541,6 +686,21 @@ impl ProofOfHeart {
             .instance()
             .get(&DataKey::ApprovalThresholdBps)
             .unwrap_or(DEFAULT_APPROVAL_THRESHOLD_BPS)
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Token).unwrap()
+    }
+
+    pub fn get_platform_fee(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::PlatformFee)
+            .unwrap_or(300)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,14 +1,23 @@
 #![cfg(test)]
 
 use super::*;
+use soroban_sdk::token::Client as TokenClient;
+use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 use soroban_sdk::{
     testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
     Address, Env, IntoVal, String, Symbol,
 };
-use soroban_sdk::token::Client as TokenClient;
-use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 
-fn setup_env<'a>() -> (Env, Address, Address, Address, Address, TokenClient<'a>, TokenAdminClient<'a>, ProofOfHeartClient<'a>) {
+fn setup_env<'a>() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    TokenClient<'a>,
+    TokenAdminClient<'a>,
+    ProofOfHeartClient<'a>,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -26,7 +35,16 @@ fn setup_env<'a>() -> (Env, Address, Address, Address, Address, TokenClient<'a>,
 
     client.init(&admin, &token.address, &300);
 
-    (env, admin, creator, contributor1, contributor2, token, token_admin, client)
+    (
+        env,
+        admin,
+        creator,
+        contributor1,
+        contributor2,
+        token,
+        token_admin,
+        client,
+    )
 }
 
 #[test]
@@ -37,20 +55,65 @@ fn test_create_and_validation() {
     let desc = String::from_str(&env, "Teaching science to kids");
 
     // Test goal validation
-    let res = client.try_create_campaign(&creator, &title, &desc, &0, &30, &Category::Publisher, &false, &0);
+    let res = client.try_create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &0,
+        &30,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
     assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalMustBePositive);
 
     // Test duration validation
-    let res = client.try_create_campaign(&creator, &title, &desc, &500, &0, &Category::Publisher, &false, &0);
+    let res = client.try_create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &500,
+        &0,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
     assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
 
-    let res = client.try_create_campaign(&creator, &title, &desc, &500, &400, &Category::Publisher, &false, &0);
+    let res = client.try_create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &500,
+        &400,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
     assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
 
-    let res = client.try_create_campaign(&creator, &title, &desc, &500, &30, &Category::Educator, &true, &1000);
+    let res = client.try_create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &500,
+        &30,
+        &Category::Educator,
+        &true,
+        &1000,
+    );
     assert_eq!(res.unwrap_err().unwrap(), Error::RevenueShareOnlyForStartup);
 
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &2000, &30, &Category::EducationalStartup, &true, &1500);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &2000,
+        &30,
+        &Category::EducationalStartup,
+        &true,
+        &1500,
+    );
     assert_eq!(campaign_id, 1);
 
     let campaign = client.get_campaign(&campaign_id);
@@ -68,7 +131,16 @@ fn test_contribute_and_withdraw_success() {
 
     let title = String::from_str(&env, "Code Camp");
     let desc = String::from_str(&env, "Learn Rust");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Educator, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &30,
+        &Category::Educator,
+        &false,
+        &0,
+    );
 
     client.contribute(&campaign_id, &contributor1, &1000);
 
@@ -88,11 +160,21 @@ fn test_contribute_and_withdraw_success() {
 
 #[test]
 fn test_creator_cannot_contribute_to_own_campaign() {
-    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) = setup_env();
+    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
 
     let title = String::from_str(&env, "Self Funding Block");
     let desc = String::from_str(&env, "Creator should not contribute");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Educator, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &30,
+        &Category::Educator,
+        &false,
+        &0,
+    );
 
     let res = client.try_contribute(&campaign_id, &creator, &100);
     assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
@@ -100,14 +182,24 @@ fn test_creator_cannot_contribute_to_own_campaign() {
 
 #[test]
 fn test_cancel_and_refund() {
-    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) = setup_env();
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
 
     token_admin.mint(&contributor1, &2000);
     token_admin.mint(&contributor2, &1000);
 
     let title = String::from_str(&env, "Failed Idea");
     let desc = String::from_str(&env, "Desc");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &5000, &10, &Category::Learner, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &5000,
+        &10,
+        &Category::Learner,
+        &false,
+        &0,
+    );
 
     client.contribute(&campaign_id, &contributor1, &1000);
     client.contribute(&campaign_id, &contributor2, &500);
@@ -126,13 +218,23 @@ fn test_cancel_and_refund() {
 
 #[test]
 fn test_claim_refund_requires_contributor_auth() {
-    let (env, _admin, creator, contributor1, _contributor2, token, token_admin, client) = setup_env();
+    let (env, _admin, creator, contributor1, _contributor2, token, token_admin, client) =
+        setup_env();
 
     token_admin.mint(&contributor1, &2000);
 
     let title = String::from_str(&env, "Auth Refund");
     let desc = String::from_str(&env, "Only contributor can claim");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &5000, &10, &Category::Learner, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &5000,
+        &10,
+        &Category::Learner,
+        &false,
+        &0,
+    );
 
     client.contribute(&campaign_id, &contributor1, &1000);
     client.cancel_campaign(&campaign_id);
@@ -160,7 +262,8 @@ fn test_claim_refund_requires_contributor_auth() {
 
 #[test]
 fn test_pull_based_revenue_distribution() {
-    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) = setup_env();
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
 
     token_admin.mint(&contributor1, &1000);
     token_admin.mint(&contributor2, &1000);
@@ -168,26 +271,38 @@ fn test_pull_based_revenue_distribution() {
 
     let title = String::from_str(&env, "Next Gen AI");
     let desc = String::from_str(&env, "Build AI");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &2000, &30, &Category::EducationalStartup, &true, &2000); 
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &2000,
+        &30,
+        &Category::EducationalStartup,
+        &true,
+        &2000,
+    );
 
     client.contribute(&campaign_id, &contributor1, &1000);
     client.contribute(&campaign_id, &contributor2, &1000);
 
     client.withdraw_funds(&campaign_id);
-    
+
     // Deposit revenue
     client.deposit_revenue(&campaign_id, &5000);
     assert_eq!(client.get_revenue_pool(&campaign_id), 5000);
 
     client.claim_revenue(&campaign_id, &contributor1);
     assert_eq!(token.balance(&contributor1), 2500);
-    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 2500);
+    assert_eq!(
+        client.get_revenue_claimed(&campaign_id, &contributor1),
+        2500
+    );
 
     client.deposit_revenue(&campaign_id, &1000);
     assert_eq!(client.get_revenue_pool(&campaign_id), 6000);
 
     client.claim_revenue(&campaign_id, &contributor1);
-    assert_eq!(token.balance(&contributor1), 3000); 
+    assert_eq!(token.balance(&contributor1), 3000);
 
     client.claim_revenue(&campaign_id, &contributor2);
     assert_eq!(token.balance(&contributor2), 3000);
@@ -197,11 +312,20 @@ fn test_pull_based_revenue_distribution() {
 fn test_failure_states() {
     let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
     token_admin.mint(&contributor1, &5000);
-    
+
     let title = String::from_str(&env, "Deadline Test");
     let desc = String::from_str(&env, "Desc");
     let duration_days = 2;
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &duration_days, &Category::Educator, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &duration_days,
+        &Category::Educator,
+        &false,
+        &0,
+    );
 
     let res = client.try_withdraw_funds(&campaign_id);
     assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
@@ -211,7 +335,16 @@ fn test_failure_states() {
     let res = client.try_withdraw_funds(&campaign_id);
     assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalNotReached);
 
-    env.ledger().set(soroban_sdk::testutils::LedgerInfo { timestamp: env.ledger().timestamp() + (duration_days * 86450), protocol_version: 22, sequence_number: env.ledger().sequence(), network_id: [0; 32], base_reserve: 10, min_temp_entry_ttl: 10, min_persistent_entry_ttl: 10, max_entry_ttl: 10 }); 
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: env.ledger().timestamp() + (duration_days * 86450),
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
 
     let res = client.try_contribute(&campaign_id, &contributor1, &500);
     assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
@@ -226,7 +359,8 @@ fn test_failure_states() {
 
 #[test]
 fn test_get_version() {
-    let (_env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) = setup_env();
+    let (_env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
 
     // init stores CONTRACT_VERSION (1) in instance storage
     assert_eq!(client.get_version(), 1u32);
@@ -234,11 +368,21 @@ fn test_get_version() {
 
 #[test]
 fn test_admin_verify_campaign_success() {
-    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) = setup_env();
+    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
 
     let title = String::from_str(&env, "Admin Verification");
     let desc = String::from_str(&env, "Admin verifies campaign");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Educator, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &30,
+        &Category::Educator,
+        &false,
+        &0,
+    );
 
     client.verify_campaign(&campaign_id);
     let campaign = client.get_campaign(&campaign_id);
@@ -247,11 +391,21 @@ fn test_admin_verify_campaign_success() {
 
 #[test]
 fn test_admin_verify_campaign_duplicate_attempt() {
-    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) = setup_env();
+    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
 
     let title = String::from_str(&env, "Duplicate Verification");
     let desc = String::from_str(&env, "Cannot verify twice");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Publisher, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &30,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
 
     client.verify_campaign(&campaign_id);
     let res = client.try_verify_campaign(&campaign_id);
@@ -260,7 +414,8 @@ fn test_admin_verify_campaign_duplicate_attempt() {
 
 #[test]
 fn test_community_voting_verification_success() {
-    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) = setup_env();
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
     let voter3 = Address::generate(&env);
 
     token_admin.mint(&contributor1, &100);
@@ -269,7 +424,16 @@ fn test_community_voting_verification_success() {
 
     let title = String::from_str(&env, "Community Verified");
     let desc = String::from_str(&env, "Verify by voting");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &1000, &30, &Category::Educator, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &1000,
+        &30,
+        &Category::Educator,
+        &false,
+        &0,
+    );
 
     client.vote_on_campaign(&campaign_id, &contributor1, &true);
     client.vote_on_campaign(&campaign_id, &contributor2, &true);
@@ -293,7 +457,16 @@ fn test_vote_prevents_double_voting_and_requires_token_holder() {
 
     let title = String::from_str(&env, "Vote Safety");
     let desc = String::from_str(&env, "No duplicate votes");
-    let campaign_id = client.create_campaign(&creator, &title, &desc, &500, &30, &Category::Learner, &false, &0);
+    let campaign_id = client.create_campaign(
+        &creator,
+        &title,
+        &desc,
+        &500,
+        &30,
+        &Category::Learner,
+        &false,
+        &0,
+    );
 
     client.vote_on_campaign(&campaign_id, &contributor1, &true);
 
@@ -306,7 +479,8 @@ fn test_vote_prevents_double_voting_and_requires_token_holder() {
 
 #[test]
 fn test_verify_campaign_quorum_and_threshold_edges() {
-    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) = setup_env();
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
     let voter3 = Address::generate(&env);
     let voter4 = Address::generate(&env);
 
@@ -321,7 +495,16 @@ fn test_verify_campaign_quorum_and_threshold_edges() {
 
     let title1 = String::from_str(&env, "Quorum Campaign");
     let desc1 = String::from_str(&env, "Needs 4 votes");
-    let campaign_id_1 = client.create_campaign(&creator, &title1, &desc1, &700, &30, &Category::Publisher, &false, &0);
+    let campaign_id_1 = client.create_campaign(
+        &creator,
+        &title1,
+        &desc1,
+        &700,
+        &30,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
 
     client.vote_on_campaign(&campaign_id_1, &contributor1, &true);
     client.vote_on_campaign(&campaign_id_1, &contributor2, &true);
@@ -336,7 +519,16 @@ fn test_verify_campaign_quorum_and_threshold_edges() {
 
     let title2 = String::from_str(&env, "Threshold Campaign");
     let desc2 = String::from_str(&env, "Fails threshold");
-    let campaign_id_2 = client.create_campaign(&creator, &title2, &desc2, &700, &30, &Category::Publisher, &false, &0);
+    let campaign_id_2 = client.create_campaign(
+        &creator,
+        &title2,
+        &desc2,
+        &700,
+        &30,
+        &Category::Publisher,
+        &false,
+        &0,
+    );
 
     client.vote_on_campaign(&campaign_id_2, &contributor1, &true);
     client.vote_on_campaign(&campaign_id_2, &contributor2, &true);
@@ -349,11 +541,32 @@ fn test_verify_campaign_quorum_and_threshold_edges() {
 
 #[test]
 fn test_update_platform_fee() {
-    let (_env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) = setup_env();
+    let (_env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
 
     let result = client.try_update_platform_fee(&500);
-    assert!(result.is_ok(), "Admin should be able to update platform fee");
+    assert!(
+        result.is_ok(),
+        "Admin should be able to update platform fee"
+    );
 
     let result = client.try_update_platform_fee(&5000);
     assert!(result.is_ok(), "Fee update should succeed even when capped");
+}
+
+#[test]
+fn test_reinit_prevention() {
+    let (env, admin, _, _, _, token, _, client) = setup_env();
+
+    let attacker = Address::generate(&env);
+    let fake_token = Address::generate(&env);
+
+    // Attempt re-initialization with different values — must be rejected
+    let res = client.try_init(&attacker, &fake_token, &0);
+    assert!(res.is_err()); // Should fail with AlreadyInitialized
+
+    // Verify original values remain unchanged after rejected re-init
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token.address);
+    assert_eq!(client.get_platform_fee(), 300);
 }


### PR DESCRIPTION
- Add AlreadyInitialized error variant (Error::AlreadyInitialized = 20)
- Guard init() with a storage presence check to prevent re-initialization; init now returns Result<(), Error> instead of ()
- Add get_admin, get_token, get_platform_fee getter functions (#13)
- Add test_reinit_prevention: verifies second init call is rejected and original admin/token/fee values remain unchanged
- Fix all clippy lints (too_many_arguments, manual_range_contains, unexpected_cfgs) and apply rustfmt across both files

## 📌 Description
Provide a clear and concise description of the changes in this PR.

## 🔗 Related Issues
Closes #16 

## 🧪 Changes Made
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation update

## ✅ Checklist
- [ ] Code compiles successfully
- [ ] Tests added/updated and passing
- [ ] Linting passes (no warnings/errors)
- [ ] Documentation updated (if required)
- [ ] No breaking changes (or clearly documented)

## ⚠️ Breaking Changes
If this PR introduces breaking changes, describe them here.

## 📸 Screenshots (if applicable)
Add screenshots to help reviewers understand the changes.

## 🧩 Additional Notes
Anything else reviewers should know.