### PR TITLE
refactor(contract): split monolithic lib.rs into focused modules

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::contracterror;
+
+/// Represents a distinct error type that can occur within the contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAuthorized = 1,
+    CampaignNotFound = 2,
+    CampaignNotActive = 3,
+    FundingGoalMustBePositive = 4,
+    InvalidDuration = 5,
+    InvalidRevenueShare = 6,
+    RevenueShareOnlyForStartup = 7,
+    DeadlinePassed = 8,
+    ContributionMustBePositive = 9,
+    DeadlineNotPassed = 10,
+    FundsAlreadyWithdrawn = 11,
+    FundingGoalNotReached = 12,
+    NoFundsToWithdraw = 13,
+    CampaignAlreadyVerified = 14,
+    ValidationFailed = 15,
+    AlreadyVoted = 16,
+    NotTokenHolder = 17,
+    VotingQuorumNotMet = 18,
+    VotingThresholdNotMet = 19,
+    AlreadyInitialized = 20,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,85 +8,15 @@
 /// is included in the upgrade transaction.
 const CONTRACT_VERSION: u32 = 1;
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, Env, String,
-};
+mod errors;
+mod storage;
+mod types;
 
-/// Represents a category for a campaign, determining its type and eligibility for revenue sharing.
-#[contracttype]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Category {
-    Learner = 0,
-    EducationalStartup = 1,
-    Educator = 2,
-    Publisher = 3,
-}
+pub use errors::Error;
+pub use types::*;
 
-/// Represents a distinct error type that can occur within the contract.
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum Error {
-    NotAuthorized = 1,
-    CampaignNotFound = 2,
-    CampaignNotActive = 3,
-    FundingGoalMustBePositive = 4,
-    InvalidDuration = 5,
-    InvalidRevenueShare = 6,
-    RevenueShareOnlyForStartup = 7,
-    DeadlinePassed = 8,
-    ContributionMustBePositive = 9,
-    DeadlineNotPassed = 10,
-    FundsAlreadyWithdrawn = 11,
-    FundingGoalNotReached = 12,
-    NoFundsToWithdraw = 13,
-    CampaignAlreadyVerified = 14,
-    ValidationFailed = 15,
-    AlreadyVoted = 16,
-    NotTokenHolder = 17,
-    VotingQuorumNotMet = 18,
-    VotingThresholdNotMet = 19,
-    AlreadyInitialized = 20,
-}
-
-/// Stores all details related to a funding campaign.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Campaign {
-    pub id: u32,
-    pub creator: Address,
-    pub title: String,
-    pub description: String,
-    pub funding_goal: i128,
-    pub deadline: u64,
-    pub amount_raised: i128,
-    pub is_active: bool,
-    pub funds_withdrawn: bool,
-    pub is_cancelled: bool,
-    pub is_verified: bool,
-    pub category: Category,
-    pub has_revenue_sharing: bool,
-    pub revenue_share_percentage: u32,
-}
-
-/// Keys representing the unique storage state for the contract.
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    Token,
-    PlatformFee,
-    CampaignCount,
-    Campaign(u32),
-    Contribution(u32, Address),
-    RevenuePool(u32),
-    RevenueClaimed(u32, Address),
-    Version,
-    ApproveVotes(u32),
-    RejectVotes(u32),
-    HasVoted(u32, Address),
-    MinVotesQuorum,
-    ApprovalThresholdBps,
-}
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
+use storage::*;
 
 /// The main contract struct for the Proof of Heart Stellar implementation.
 #[contract]
@@ -108,32 +38,20 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `admin.require_auth()`.
     pub fn init(env: Env, admin: Address, token: Address, platform_fee: u32) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Admin) {
+        if has_admin(&env) {
             return Err(Error::AlreadyInitialized);
         }
         admin.require_auth();
-        env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Token, &token);
+        set_admin(&env, &admin);
+        set_token(&env, &token);
 
-        let valid_fee = if platform_fee > 1000 {
-            1000
-        } else {
-            platform_fee
-        }; // Max 10% limit
-        env.storage()
-            .instance()
-            .set(&DataKey::PlatformFee, &valid_fee);
-        env.storage().instance().set(&DataKey::CampaignCount, &0u32);
-        env.storage()
-            .instance()
-            .set(&DataKey::Version, &CONTRACT_VERSION);
-        env.storage()
-            .instance()
-            .set(&DataKey::MinVotesQuorum, &DEFAULT_MIN_VOTES_QUORUM);
-        env.storage().instance().set(
-            &DataKey::ApprovalThresholdBps,
-            &DEFAULT_APPROVAL_THRESHOLD_BPS,
-        );
+        let valid_fee = if platform_fee > 1000 { 1000 } else { platform_fee }; // Max 10% limit
+        set_platform_fee(&env, valid_fee);
+        set_campaign_count(&env, 0);
+        set_version(&env, CONTRACT_VERSION);
+        set_min_votes_quorum(&env, DEFAULT_MIN_VOTES_QUORUM);
+        set_approval_threshold_bps(&env, DEFAULT_APPROVAL_THRESHOLD_BPS);
+
         env.events()
             .publish(("initialized", admin.clone()), (token.clone(), valid_fee));
         Ok(())
@@ -182,21 +100,15 @@ impl ProofOfHeart {
         if description.len() == 0 || description.len() > 1000 {
             return Err(Error::ValidationFailed);
         }
-
         if category != Category::EducationalStartup && has_revenue_sharing {
             return Err(Error::RevenueShareOnlyForStartup);
         }
-
         if has_revenue_sharing && (revenue_share_percentage == 0 || revenue_share_percentage > 5000)
         {
             return Err(Error::InvalidRevenueShare);
         }
 
-        let mut count: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::CampaignCount)
-            .unwrap_or(0);
+        let mut count = get_campaign_count(&env);
         count += 1;
 
         let current_time = env.ledger().timestamp();
@@ -219,15 +131,9 @@ impl ProofOfHeart {
             revenue_share_percentage,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(count), &campaign);
-        env.storage()
-            .instance()
-            .set(&DataKey::CampaignCount, &count);
-        env.storage()
-            .instance()
-            .set(&DataKey::RevenuePool(count), &0i128);
+        set_campaign(&env, count, &campaign);
+        set_campaign_count(&env, count);
+        set_revenue_pool(&env, count, 0);
 
         env.events()
             .publish(("campaign_created", count, creator), title);
@@ -261,11 +167,8 @@ impl ProofOfHeart {
             return Err(Error::ContributionMustBePositive);
         }
 
-        let mut campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let mut campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         if !campaign.is_active || campaign.is_cancelled {
             return Err(Error::CampaignNotActive);
@@ -277,21 +180,15 @@ impl ProofOfHeart {
             return Err(Error::DeadlinePassed);
         }
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_addr = get_token(&env);
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&contributor, &env.current_contract_address(), &amount);
 
         campaign.amount_raised += amount;
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(campaign_id), &campaign);
+        set_campaign(&env, campaign_id, &campaign);
 
-        let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
-        let current_contribution: i128 =
-            env.storage().instance().get(&contribution_key).unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&contribution_key, &(current_contribution + amount));
+        let current = get_contribution(&env, campaign_id, &contributor);
+        set_contribution(&env, campaign_id, &contributor, current + amount);
 
         env.events()
             .publish(("contribution_made", campaign_id, contributor), amount);
@@ -311,11 +208,8 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `campaign.creator.require_auth()`.
     pub fn withdraw_funds(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let mut campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let mut campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         campaign.creator.require_auth();
 
@@ -338,22 +232,16 @@ impl ProofOfHeart {
             }
         }
 
-        let platform_fee: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::PlatformFee)
-            .unwrap_or(300);
+        let platform_fee = get_platform_fee(&env);
         let fee_amount = (campaign.amount_raised * (platform_fee as i128)) / 10000;
         let creator_amount = campaign.amount_raised - fee_amount;
 
         campaign.funds_withdrawn = true;
         campaign.is_active = false;
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(campaign_id), &campaign);
+        set_campaign(&env, campaign_id, &campaign);
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let admin_addr: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let token_addr = get_token(&env);
+        let admin_addr = get_admin(&env);
         let client = token::Client::new(&env, &token_addr);
 
         client.transfer(&env.current_contract_address(), &admin_addr, &fee_amount);
@@ -376,11 +264,8 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `campaign.creator.require_auth()`.
     pub fn cancel_campaign(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let mut campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let mut campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
         campaign.creator.require_auth();
 
         if campaign.funds_withdrawn {
@@ -389,9 +274,7 @@ impl ProofOfHeart {
 
         campaign.is_cancelled = true;
         campaign.is_active = false;
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(campaign_id), &campaign);
+        set_campaign(&env, campaign_id, &campaign);
 
         env.events()
             .publish(("campaign_cancelled", campaign_id), ());
@@ -406,11 +289,8 @@ impl ProofOfHeart {
     pub fn claim_refund(env: Env, campaign_id: u32, contributor: Address) -> Result<(), Error> {
         contributor.require_auth();
 
-        let campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         let failed_due_to_goal = env.ledger().timestamp() > campaign.deadline
             && campaign.amount_raised < campaign.funding_goal;
@@ -419,15 +299,14 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
-        let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
-        let amount: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
+        let amount = get_contribution(&env, campaign_id, &contributor);
         if amount == 0 {
             return Err(Error::NoFundsToWithdraw);
         }
 
-        env.storage().instance().set(&contribution_key, &0i128);
+        set_contribution(&env, campaign_id, &contributor, 0);
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_addr = get_token(&env);
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&env.current_contract_address(), &contributor, &amount);
 
@@ -442,11 +321,8 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `campaign.creator.require_auth()`.
     pub fn deposit_revenue(env: Env, campaign_id: u32, amount: i128) -> Result<(), Error> {
-        let campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
         campaign.creator.require_auth();
 
         if amount <= 0 {
@@ -456,16 +332,12 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_addr = get_token(&env);
         let client = token::Client::new(&env, &token_addr);
-
         client.transfer(&campaign.creator, &env.current_contract_address(), &amount);
 
-        let pool_key = DataKey::RevenuePool(campaign_id);
-        let current_pool: i128 = env.storage().instance().get(&pool_key).unwrap_or(0);
-        env.storage()
-            .instance()
-            .set(&pool_key, &(current_pool + amount));
+        let current_pool = get_revenue_pool(&env, campaign_id);
+        set_revenue_pool(&env, campaign_id, current_pool + amount);
 
         env.events()
             .publish(("revenue_deposited", campaign_id), amount);
@@ -475,41 +347,29 @@ impl ProofOfHeart {
 
     /// Claims a share of the revenue pool proportional to the individual contributor's contribution.
     pub fn claim_revenue(env: Env, campaign_id: u32, contributor: Address) -> Result<(), Error> {
-        let campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
         if !campaign.has_revenue_sharing {
             return Err(Error::ValidationFailed);
         }
 
-        let contribution_key = DataKey::Contribution(campaign_id, contributor.clone());
-        let contribution: i128 = env.storage().instance().get(&contribution_key).unwrap_or(0);
-
+        let contribution = get_contribution(&env, campaign_id, &contributor);
         if contribution == 0 {
             return Err(Error::ValidationFailed);
         }
 
-        let pool_key = DataKey::RevenuePool(campaign_id);
-        let total_pool: i128 = env.storage().instance().get(&pool_key).unwrap_or(0);
-
-        let total_due_to_contributor = (contribution * total_pool) / campaign.amount_raised;
-
-        let claimed_key = DataKey::RevenueClaimed(campaign_id, contributor.clone());
-        let already_claimed: i128 = env.storage().instance().get(&claimed_key).unwrap_or(0);
-
-        let claimable = total_due_to_contributor - already_claimed;
+        let total_pool = get_revenue_pool(&env, campaign_id);
+        let total_due = (contribution * total_pool) / campaign.amount_raised;
+        let already_claimed = get_revenue_claimed(&env, campaign_id, &contributor);
+        let claimable = total_due - already_claimed;
 
         if claimable <= 0 {
             return Err(Error::NoFundsToWithdraw);
         }
 
-        env.storage()
-            .instance()
-            .set(&claimed_key, &(already_claimed + claimable));
+        set_revenue_claimed(&env, campaign_id, &contributor, already_claimed + claimable);
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_addr = get_token(&env);
         let client = token::Client::new(&env, &token_addr);
         client.transfer(&env.current_contract_address(), &contributor, &claimable);
 
@@ -535,7 +395,7 @@ impl ProofOfHeart {
         approval_threshold_bps: u32,
     ) -> Result<(), Error> {
         admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let stored_admin = get_admin(&env);
         if admin != stored_admin {
             return Err(Error::NotAuthorized);
         }
@@ -544,12 +404,8 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::MinVotesQuorum, &min_votes_quorum);
-        env.storage()
-            .instance()
-            .set(&DataKey::ApprovalThresholdBps, &approval_threshold_bps);
+        set_min_votes_quorum(&env, min_votes_quorum);
+        set_approval_threshold_bps(&env, approval_threshold_bps);
 
         Ok(())
     }
@@ -566,11 +422,8 @@ impl ProofOfHeart {
     ) -> Result<(), Error> {
         voter.require_auth();
 
-        let campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         if campaign.is_verified {
             return Err(Error::CampaignAlreadyVerified);
@@ -579,34 +432,26 @@ impl ProofOfHeart {
             return Err(Error::CampaignNotActive);
         }
 
-        let token_addr: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let token_addr = get_token(&env);
         let token_client = token::Client::new(&env, &token_addr);
         let voter_balance = token_client.balance(&voter);
         if voter_balance <= 0 {
             return Err(Error::NotTokenHolder);
         }
 
-        let has_voted_key = DataKey::HasVoted(campaign_id, voter.clone());
-        let has_voted: bool = env
-            .storage()
-            .instance()
-            .get(&has_voted_key)
-            .unwrap_or(false);
-        if has_voted {
+        if get_has_voted(&env, campaign_id, &voter) {
             return Err(Error::AlreadyVoted);
         }
 
         if approve {
-            let key = DataKey::ApproveVotes(campaign_id);
-            let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
-            env.storage().instance().set(&key, &(current + 1));
+            let current = get_approve_votes(&env, campaign_id);
+            set_approve_votes(&env, campaign_id, current + 1);
         } else {
-            let key = DataKey::RejectVotes(campaign_id);
-            let current: u32 = env.storage().instance().get(&key).unwrap_or(0);
-            env.storage().instance().set(&key, &(current + 1));
+            let current = get_reject_votes(&env, campaign_id);
+            set_reject_votes(&env, campaign_id, current + 1);
         }
 
-        env.storage().instance().set(&has_voted_key, &true);
+        set_has_voted(&env, campaign_id, &voter);
         env.events()
             .publish(("campaign_vote_cast", campaign_id, voter), approve);
 
@@ -618,23 +463,18 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `admin.require_auth()`.
     pub fn verify_campaign(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
 
-        let mut campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let mut campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         if campaign.is_verified {
             return Err(Error::CampaignAlreadyVerified);
         }
 
         campaign.is_verified = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(campaign_id), &campaign);
+        set_campaign(&env, campaign_id, &campaign);
         env.events().publish(("campaign_verified", campaign_id), ());
 
         Ok(())
@@ -642,51 +482,30 @@ impl ProofOfHeart {
 
     /// Checks if a campaign meets community verification thresholds and marks it verified.
     pub fn verify_campaign_with_votes(env: Env, campaign_id: u32) -> Result<(), Error> {
-        let mut campaign: Campaign = env
-            .storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)?;
+        let mut campaign =
+            get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)?;
 
         if campaign.is_verified {
             return Err(Error::CampaignAlreadyVerified);
         }
 
-        let approve_votes: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::ApproveVotes(campaign_id))
-            .unwrap_or(0);
-        let reject_votes: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::RejectVotes(campaign_id))
-            .unwrap_or(0);
+        let approve_votes = get_approve_votes(&env, campaign_id);
+        let reject_votes = get_reject_votes(&env, campaign_id);
         let total_votes = approve_votes + reject_votes;
 
-        let min_votes_quorum: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::MinVotesQuorum)
-            .unwrap_or(DEFAULT_MIN_VOTES_QUORUM);
+        let min_votes_quorum = get_min_votes_quorum(&env, DEFAULT_MIN_VOTES_QUORUM);
         if total_votes < min_votes_quorum {
             return Err(Error::VotingQuorumNotMet);
         }
 
-        let approval_threshold_bps: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::ApprovalThresholdBps)
-            .unwrap_or(DEFAULT_APPROVAL_THRESHOLD_BPS);
+        let approval_threshold_bps = get_approval_threshold_bps(&env, DEFAULT_APPROVAL_THRESHOLD_BPS);
         let approval_bps = (approve_votes * 10000) / total_votes;
         if approval_bps < approval_threshold_bps {
             return Err(Error::VotingThresholdNotMet);
         }
 
         campaign.is_verified = true;
-        env.storage()
-            .instance()
-            .set(&DataKey::Campaign(campaign_id), &campaign);
+        set_campaign(&env, campaign_id, &campaign);
         env.events()
             .publish(("campaign_verified", campaign_id), approve_votes);
 
@@ -698,40 +517,28 @@ impl ProofOfHeart {
     /// # Returns
     /// `Result<Campaign, Error>` where the Error is `CampaignNotFound` if the ID is invalid.
     pub fn get_campaign(env: Env, campaign_id: u32) -> Result<Campaign, Error> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Campaign(campaign_id))
-            .ok_or(Error::CampaignNotFound)
+        get_campaign(&env, campaign_id).ok_or(Error::CampaignNotFound)
     }
 
     /// Gets the contributor's contribution amount for a specific campaign.
     pub fn get_contribution(env: Env, campaign_id: u32, contributor: Address) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::Contribution(campaign_id, contributor))
-            .unwrap_or(0)
+        get_contribution(&env, campaign_id, &contributor)
     }
 
     /// Gets the total revenue pool for a given campaign.
     pub fn get_revenue_pool(env: Env, campaign_id: u32) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::RevenuePool(campaign_id))
-            .unwrap_or(0)
+        get_revenue_pool(&env, campaign_id)
     }
 
     /// Gets the total revenue claimed by a specific contributor.
     pub fn get_revenue_claimed(env: Env, campaign_id: u32, contributor: Address) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::RevenueClaimed(campaign_id, contributor))
-            .unwrap_or(0)
+        get_revenue_claimed(&env, campaign_id, &contributor)
     }
 
     /// Returns the current contract version stored in instance storage.
     /// A return value of 0 indicates the contract was initialized before version tracking was added.
     pub fn get_version(env: Env) -> u32 {
-        env.storage().instance().get(&DataKey::Version).unwrap_or(0)
+        get_version(&env)
     }
 
     /// Updates the global platform fee.
@@ -739,74 +546,50 @@ impl ProofOfHeart {
     /// # Authorization
     /// Requires `admin.require_auth()`.
     pub fn update_platform_fee(env: Env, new_fee: u32) -> Result<(), Error> {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin = get_admin(&env);
         admin.require_auth();
         let valid_fee = if new_fee > 1000 { 1000 } else { new_fee };
-        let old_fee: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::PlatformFee)
-            .unwrap_or(300);
-        env.storage()
-            .instance()
-            .set(&DataKey::PlatformFee, &valid_fee);
+        let old_fee = get_platform_fee(&env);
+        set_platform_fee(&env, valid_fee);
         env.events().publish(("fee_updated",), (old_fee, valid_fee));
         Ok(())
     }
 
     /// Gets the number of recorded approval votes for a campaign.
     pub fn get_approve_votes(env: Env, campaign_id: u32) -> u32 {
-        env.storage()
-            .instance()
-            .get(&DataKey::ApproveVotes(campaign_id))
-            .unwrap_or(0)
+        get_approve_votes(&env, campaign_id)
     }
 
     /// Gets the number of recorded rejection votes for a campaign.
     pub fn get_reject_votes(env: Env, campaign_id: u32) -> u32 {
-        env.storage()
-            .instance()
-            .get(&DataKey::RejectVotes(campaign_id))
-            .unwrap_or(0)
+        get_reject_votes(&env, campaign_id)
     }
 
     /// Checks if a voter has already voted on a specific campaign.
     pub fn has_voted(env: Env, campaign_id: u32, voter: Address) -> bool {
-        env.storage()
-            .instance()
-            .get(&DataKey::HasVoted(campaign_id, voter))
-            .unwrap_or(false)
+        get_has_voted(&env, campaign_id, &voter)
     }
 
     /// Gets the minimum votes needed to reach quorum.
     pub fn get_min_votes_quorum(env: Env) -> u32 {
-        env.storage()
-            .instance()
-            .get(&DataKey::MinVotesQuorum)
-            .unwrap_or(DEFAULT_MIN_VOTES_QUORUM)
+        get_min_votes_quorum(&env, DEFAULT_MIN_VOTES_QUORUM)
     }
 
     /// Gets the required approval threshold in basis points.
     pub fn get_approval_threshold_bps(env: Env) -> u32 {
-        env.storage()
-            .instance()
-            .get(&DataKey::ApprovalThresholdBps)
-            .unwrap_or(DEFAULT_APPROVAL_THRESHOLD_BPS)
+        get_approval_threshold_bps(&env, DEFAULT_APPROVAL_THRESHOLD_BPS)
     }
 
     pub fn get_admin(env: Env) -> Address {
-        env.storage().instance().get(&DataKey::Admin).unwrap()
+        get_admin(&env)
     }
 
     pub fn get_token(env: Env) -> Address {
-        env.storage().instance().get(&DataKey::Token).unwrap()
+        get_token(&env)
     }
 
     pub fn get_platform_fee(env: Env) -> u32 {
-        env.storage()
-            .instance()
-            .get(&DataKey::PlatformFee)
-            .unwrap_or(300)
+        get_platform_fee(&env)
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,188 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{Campaign, DataKey};
+
+// ── Campaign ──────────────────────────────────────────────────────────────────
+
+pub fn get_campaign(env: &Env, campaign_id: u32) -> Option<Campaign> {
+    env.storage().instance().get(&DataKey::Campaign(campaign_id))
+}
+
+pub fn set_campaign(env: &Env, campaign_id: u32, campaign: &Campaign) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Campaign(campaign_id), campaign);
+}
+
+// ── Campaign count ────────────────────────────────────────────────────────────
+
+pub fn get_campaign_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::CampaignCount)
+        .unwrap_or(0)
+}
+
+pub fn set_campaign_count(env: &Env, count: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CampaignCount, &count);
+}
+
+// ── Admin / token / fee ───────────────────────────────────────────────────────
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Admin).unwrap()
+}
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&DataKey::Admin, admin);
+}
+
+pub fn has_admin(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Admin)
+}
+
+pub fn get_token(env: &Env) -> Address {
+    env.storage().instance().get(&DataKey::Token).unwrap()
+}
+
+pub fn set_token(env: &Env, token: &Address) {
+    env.storage().instance().set(&DataKey::Token, token);
+}
+
+pub fn get_platform_fee(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::PlatformFee)
+        .unwrap_or(300)
+}
+
+pub fn set_platform_fee(env: &Env, fee: u32) {
+    env.storage().instance().set(&DataKey::PlatformFee, &fee);
+}
+
+// ── Contributions ─────────────────────────────────────────────────────────────
+
+pub fn get_contribution(env: &Env, campaign_id: u32, contributor: &Address) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::Contribution(campaign_id, contributor.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_contribution(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
+    env.storage().instance().set(
+        &DataKey::Contribution(campaign_id, contributor.clone()),
+        &amount,
+    );
+}
+
+// ── Revenue ───────────────────────────────────────────────────────────────────
+
+pub fn get_revenue_pool(env: &Env, campaign_id: u32) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RevenuePool(campaign_id))
+        .unwrap_or(0)
+}
+
+pub fn set_revenue_pool(env: &Env, campaign_id: u32, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::RevenuePool(campaign_id), &amount);
+}
+
+pub fn get_revenue_claimed(env: &Env, campaign_id: u32, contributor: &Address) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RevenueClaimed(campaign_id, contributor.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_revenue_claimed(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
+    env.storage().instance().set(
+        &DataKey::RevenueClaimed(campaign_id, contributor.clone()),
+        &amount,
+    );
+}
+
+// ── Voting ────────────────────────────────────────────────────────────────────
+
+pub fn get_approve_votes(env: &Env, campaign_id: u32) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ApproveVotes(campaign_id))
+        .unwrap_or(0)
+}
+
+pub fn set_approve_votes(env: &Env, campaign_id: u32, count: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ApproveVotes(campaign_id), &count);
+}
+
+pub fn get_reject_votes(env: &Env, campaign_id: u32) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::RejectVotes(campaign_id))
+        .unwrap_or(0)
+}
+
+pub fn set_reject_votes(env: &Env, campaign_id: u32, count: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::RejectVotes(campaign_id), &count);
+}
+
+pub fn get_has_voted(env: &Env, campaign_id: u32, voter: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::HasVoted(campaign_id, voter.clone()))
+        .unwrap_or(false)
+}
+
+pub fn set_has_voted(env: &Env, campaign_id: u32, voter: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::HasVoted(campaign_id, voter.clone()), &true);
+}
+
+pub fn get_min_votes_quorum(env: &Env, default: u32) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinVotesQuorum)
+        .unwrap_or(default)
+}
+
+pub fn set_min_votes_quorum(env: &Env, value: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MinVotesQuorum, &value);
+}
+
+pub fn get_approval_threshold_bps(env: &Env, default: u32) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ApprovalThresholdBps)
+        .unwrap_or(default)
+}
+
+pub fn set_approval_threshold_bps(env: &Env, value: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ApprovalThresholdBps, &value);
+}
+
+// ── Version ───────────────────────────────────────────────────────────────────
+
+pub fn set_version(env: &Env, version: u32) {
+    env.storage().instance().set(&DataKey::Version, &version);
+}
+
+pub fn get_version(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::Version)
+        .unwrap_or(0)
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,50 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Represents a category for a campaign, determining its type and eligibility for revenue sharing.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Category {
+    Learner = 0,
+    EducationalStartup = 1,
+    Educator = 2,
+    Publisher = 3,
+}
+
+/// Stores all details related to a funding campaign.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Campaign {
+    pub id: u32,
+    pub creator: Address,
+    pub title: String,
+    pub description: String,
+    pub funding_goal: i128,
+    pub deadline: u64,
+    pub amount_raised: i128,
+    pub is_active: bool,
+    pub funds_withdrawn: bool,
+    pub is_cancelled: bool,
+    pub is_verified: bool,
+    pub category: Category,
+    pub has_revenue_sharing: bool,
+    pub revenue_share_percentage: u32,
+}
+
+/// Keys representing the unique storage state for the contract.
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Token,
+    PlatformFee,
+    CampaignCount,
+    Campaign(u32),
+    Contribution(u32, Address),
+    RevenuePool(u32),
+    RevenueClaimed(u32, Address),
+    Version,
+    ApproveVotes(u32),
+    RejectVotes(u32),
+    HasVoted(u32, Address),
+    MinVotesQuorum,
+    ApprovalThresholdBps,
+}


### PR DESCRIPTION
## Description
Splits the 314-line monolithic `lib.rs` into four focused modules so the
contract is easier to navigate, review, and extend with new features.

## Related Issue
Fixes #30

## Type of Change
- [x] Code refactoring

## Changes Made
- `src/errors.rs` — `Error` enum
- `src/types.rs` — `Category`, `Campaign`, `DataKey`
- `src/storage.rs` — named helper functions for every `env.storage()`
  read and write (`get_campaign`, `set_campaign`, `get_contribution`, etc.)
- `src/lib.rs` — module declarations, re-exports, constants, and the
  `ProofOfHeart` `contractimpl` block; all raw storage calls replaced
  with named helpers from `storage.rs`
- `src/test.rs` — unchanged

## Notes
- Zero logic changes — this is a pure structural reorganisation
- All storage defaults (`unwrap_or(0)`, `unwrap_or(false)`) are now
  centralised in `storage.rs` to prevent drift
- `pub use types::*` preserves the public API so callers of the
  generated contract client see the same types as before

## Screenshot(test and build)
<img width="1366" height="682" alt="Screenshot From 2026-03-28 16-17-30" src="https://github.com/user-attachments/assets/20e9f013-f70f-40c1-8fde-e2442a17e659" />
<img width="1366" height="669" alt="Screenshot From 2026-03-28 16-18-25" src="https://github.com/user-attachments/assets/3d9ba15f-6e61-48bd-8ddf-7f23541a8eb1" />
