### PR TITLE
feat: emit voting_params_updated event in set_voting_params

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,7 +560,20 @@ impl ProofOfHeart {
         approval_threshold_bps: u32,
     ) -> Result<(), Error> {
         Self::require_not_paused(&env)?;
-        voting::set_params(&env, admin, min_votes_quorum, approval_threshold_bps)
+        let old_quorum = get_min_votes_quorum(&env, voting::DEFAULT_MIN_VOTES_QUORUM);
+        let old_threshold =
+            get_approval_threshold_bps(&env, voting::DEFAULT_APPROVAL_THRESHOLD_BPS);
+        voting::set_params(&env, admin, min_votes_quorum, approval_threshold_bps)?;
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "voting_params_updated"),),
+            (
+                old_quorum,
+                min_votes_quorum,
+                old_threshold,
+                approval_threshold_bps,
+            ),
+        );
+        Ok(())
     }
 
     /// Pauses the contract, preventing state-changing operations.

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,7 +2,7 @@ use super::*;
 use soroban_sdk::token::Client as TokenClient;
 use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
 use soroban_sdk::{
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Ledger},
+    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events, Ledger},
     Address, Env, IntoVal, String, Symbol,
 };
 
@@ -1357,4 +1357,27 @@ fn test_no_refund_when_goal_reached() {
     // Goal was reached — refund must be rejected
     let res = client.try_claim_refund(&campaign_id, &contributor1);
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_set_voting_params_emits_event() {
+    extern crate std;
+    let (env, admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    client.set_voting_params(&admin, &5, &7000);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    std::println!("Last event: {:?}", last_event);
+
+    let topics = &last_event.1;
+    assert_eq!(topics.len(), 1);
+
+    let data_vec: soroban_sdk::Vec<u32> = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(data_vec.get(0).unwrap(), 3);
+    assert_eq!(data_vec.get(1).unwrap(), 5);
+    assert_eq!(data_vec.get(2).unwrap(), 6000);
+    assert_eq!(data_vec.get(3).unwrap(), 7000);
 }


### PR DESCRIPTION
This pull request introduces an event emission when voting parameters are updated and adds a corresponding test to verify this behavior. The main changes are grouped into contract logic updates and test coverage improvements:

**Contract logic update:**

* The `set_voting_params` method in `ProofOfHeart` now emits a `voting_params_updated` event whenever voting parameters are changed, publishing both the old and new values for quorum and approval threshold.

**Test coverage:**

* Added a new test, `test_set_voting_params_emits_event`, to ensure that updating voting parameters emits the correct event with the expected data.
* Updated imports in `src/test.rs` to include `Events` for event inspection in tests.## 📌 Description
Provide a clear and concise description of the changes in this PR.

## 🔗 Related Issues
Closes #60 

## 🧪 Changes Made
- [# ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## ✅ Checklist
- [ #] Code compiles successfully
- [ #] Tests added/updated and passing
- [ #] Linting passes (no warnings/errors)
- [ ] Documentation updated (if required)
- [ #] No breaking changes (or clearly documented)

## ⚠️ Breaking Changes
If this PR introduces breaking changes, describe them here.

## 📸 Screenshots (if applicable)
Add screenshots to help reviewers understand the changes.

## 🧩 Additional Notes
Anything else reviewers should know.