### PR TITLE
Add explicit non-revenue deposit error and close assigned issues

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,4 +59,6 @@ pub enum Error {
     CampaignNotVerified = 26,
     /// Revenue claim calculation is invalid because `amount_raised` is zero.
     AmountRaisedIsZero = 27,
+    /// Revenue deposit attempted on a campaign without revenue sharing enabled.
+    RevenueSharingNotEnabled = 28,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,7 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
         if !campaign.has_revenue_sharing {
-            return Err(Error::ValidationFailed);
+            return Err(Error::RevenueSharingNotEnabled);
         }
 
         bump_instance_ttl(&env);

--- a/src/test.rs
+++ b/src/test.rs
@@ -838,7 +838,7 @@ fn test_revenue_sharing_edge_cases() {
     let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
         setup_env();
 
-    // 1. Non-revenue campaign: check ValidationFailed
+    // 1. Non-revenue campaign: check explicit revenue-sharing error on deposit.
     let title_nr = String::from_str(&env, "No Revenue");
     let desc_nr = String::from_str(&env, "Non-revenue campaign");
     let campaign_nr = client.create_campaign(
@@ -853,6 +853,11 @@ fn test_revenue_sharing_edge_cases() {
         &0i128,
     );
     let _ = client.try_verify_campaign(&campaign_nr);
+    let deposit_res = client.try_deposit_revenue(&campaign_nr, &10);
+    assert_eq!(
+        deposit_res.unwrap_err().unwrap(),
+        Error::RevenueSharingNotEnabled
+    );
     let res = client.try_claim_revenue(&campaign_nr, &contributor1);
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
 


### PR DESCRIPTION
Closes #107
Closes #109
Closes #121
Closes #126

## Changes
- Added a dedicated contract error variant: `RevenueSharingNotEnabled`.
- Updated `deposit_revenue` to return `RevenueSharingNotEnabled` when called on campaigns without revenue sharing.
- Added test coverage in `test_revenue_sharing_edge_cases` to assert the explicit error for non-revenue campaigns.

## Testing
- `cargo test test_revenue_sharing_edge_cases`
