### PR TITLE
Fix README owner links, init token probe, and pagination semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This repository contains the **Soroban smart contract** that powers the on-chain
 
 ```bash
 # Clone the repository
-git clone https://github.com/dmystical-coder/ProofOfHeart-stellar.git
+git clone https://github.com/Iris-IV/ProofOfHeart-stellar.git
 cd ProofOfHeart-stellar
 
 # Build the contract
@@ -111,7 +111,7 @@ ProofOfHeart-stellar/
 
 | Repository | Description |
 | --- | --- |
-| [ProofOfHeart-frontend](https://github.com/dmystical-coder/ProofOfHeart-frontend) | Next.js frontend application |
+| [ProofOfHeart-frontend](https://github.com/Iris-IV/ProofOfHeart-frontend) | Next.js frontend application |
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,10 @@ impl ProofOfHeart {
         }
         admin.require_auth();
 
-        // Validate token contract by attempting to use it
+        // Validate token contract using metadata read that does not depend on
+        // admin account state/funding on the token ledger.
         let token_client = token::Client::new(&env, &token);
-        let _ = token_client.balance(&admin);
+        let _ = token_client.decimals();
 
         bump_instance_ttl(&env);
         set_admin(&env, &admin);
@@ -864,6 +865,12 @@ impl ProofOfHeart {
         get_min_voting_balance(&env)
     }
 
+    /// List campaigns in ID order.
+    ///
+    /// Pagination semantics:
+    /// - `start` is the last campaign ID already seen (exclusive cursor).
+    /// - pass `start = 0` for the first page.
+    /// - pass the last returned campaign ID as `start` for the next page.
     pub fn list_campaigns(env: Env, start: u32, limit: u32) -> soroban_sdk::Vec<Campaign> {
         let total_count = get_campaign_count(&env);
         let mut campaigns = soroban_sdk::Vec::new(&env);
@@ -887,6 +894,8 @@ impl ProofOfHeart {
         campaigns
     }
 
+    /// List active campaigns using the same exclusive-cursor semantics as
+    /// `list_campaigns` (`start` = last ID already seen).
     pub fn list_active_campaigns(env: Env, start: u32, limit: u32) -> soroban_sdk::Vec<Campaign> {
         let total_count = get_campaign_count(&env);
         let mut campaigns = soroban_sdk::Vec::new(&env);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1716,6 +1716,70 @@ fn test_set_voting_params_emits_event() {
 }
 
 #[test]
+fn test_list_campaigns_exclusive_cursor_semantics() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    for i in 0..3 {
+        let title = String::from_str(&env, "Campaign");
+        let desc = String::from_str(&env, "Desc");
+        let id = client.create_campaign(
+            &creator,
+            &title,
+            &desc,
+            &(1000 + i as i128),
+            &30,
+            &Category::Learner,
+            &false,
+            &0,
+            &0i128,
+        );
+        assert_eq!(id, (i + 1) as u32);
+    }
+
+    let page1 = client.list_campaigns(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap().id, 1);
+    assert_eq!(page1.get(1).unwrap().id, 2);
+
+    let page2 = client.list_campaigns(&2, &2);
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2.get(0).unwrap().id, 3);
+}
+
+#[test]
+fn test_list_active_campaigns_exclusive_cursor_semantics() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    for _ in 0..4 {
+        let title = String::from_str(&env, "Campaign");
+        let desc = String::from_str(&env, "Desc");
+        let _ = client.create_campaign(
+            &creator,
+            &title,
+            &desc,
+            &1000,
+            &30,
+            &Category::Learner,
+            &false,
+            &0,
+            &0i128,
+        );
+    }
+
+    // Cancel campaign id 2 so active listing filters it out.
+    client.cancel_campaign(&2);
+
+    let active1 = client.list_active_campaigns(&0, &2);
+    assert_eq!(active1.len(), 2);
+    assert_eq!(active1.get(0).unwrap().id, 1);
+    assert_eq!(active1.get(1).unwrap().id, 3);
+
+    let active2 = client.list_active_campaigns(&3, &2);
+    assert_eq!(active2.len(), 1);
+    assert_eq!(active2.get(0).unwrap().id, 4);
+}
+
+#[test]
 fn test_revenue_lifecycle_e2e() {
     let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
         setup_env();

--- a/test_snapshots/test/test_cancel_and_refund.1.json
+++ b/test_snapshots/test/test_cancel_and_refund.1.json
@@ -1737,12 +1737,10 @@
                 "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-            }
+            "data": "void"
           }
         }
       },
@@ -1760,14 +1758,11 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
+              "u32": 7
             }
           }
         }

--- a/test_snapshots/test/test_contribute_and_withdraw_success.1.json
+++ b/test_snapshots/test/test_contribute_and_withdraw_success.1.json
@@ -1505,12 +1505,10 @@
                 "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-            }
+            "data": "void"
           }
         }
       },
@@ -1528,14 +1526,11 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
+              "u32": 7
             }
           }
         }

--- a/test_snapshots/test/test_create_and_validation.1.json
+++ b/test_snapshots/test/test_create_and_validation.1.json
@@ -911,12 +911,10 @@
                 "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-            }
+            "data": "void"
           }
         }
       },
@@ -934,14 +932,11 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
+              "u32": 7
             }
           }
         }

--- a/test_snapshots/test/test_failure_states.1.json
+++ b/test_snapshots/test/test_failure_states.1.json
@@ -1361,12 +1361,10 @@
                 "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-            }
+            "data": "void"
           }
         }
       },
@@ -1384,14 +1382,11 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
+              "u32": 7
             }
           }
         }

--- a/test_snapshots/test/test_pull_based_revenue_distribution.1.json
+++ b/test_snapshots/test/test_pull_based_revenue_distribution.1.json
@@ -2328,12 +2328,10 @@
                 "bytes": "d63a954726751a876d37290072af1ee723d7d761eec3bf4191849d2116acdc73"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
-            "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-            }
+            "data": "void"
           }
         }
       },
@@ -2351,14 +2349,11 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "decimals"
               }
             ],
             "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
+              "u32": 7
             }
           }
         }


### PR DESCRIPTION
## Summary
- fix README repository owner links to `Iris-IV` in both clone instructions and related frontend repository references
- remove unnecessary `rlib` crate type to keep this leaf Soroban contract focused on `cdylib`
- harden `init` token validation by probing token metadata (`decimals`) instead of account balance, so init no longer depends on admin account funding/registration
- document and lock `list_campaigns` / `list_active_campaigns` exclusive-cursor pagination semantics with dedicated tests

## Validation
- `cargo test` (59 passed)

Closes #229
Closes #226
Closes #175
Closes #190

Made with [Cursor](https://cursor.com)