### PR TITLE
Fix campaign update and refund edge cases

### DIFF
--- a/docs/CAMPAIGN_LIFECYCLE.md
+++ b/docs/CAMPAIGN_LIFECYCLE.md
@@ -18,12 +18,14 @@ Additional derived conditions used by the contract:
 - Set on `create_campaign`: `is_active = true`, `is_cancelled = false`, `funds_withdrawn = false`, `is_verified = false`.
 - Contributions are blocked until verified: `contribute` returns `CampaignNotVerified` while `is_verified = false`.
 - Creator can still update/cancel while active (subject to each method's rules).
+- Full `update_campaign` edits are only available before verification and before any contributions.
 
 ### 2) Active + Verified
 - Reached by either:
   - `verify_campaign` (admin verification), or
   - `verify_campaign_with_votes` (community verification after quorum + threshold).
 - Once verified, contributions are allowed until the deadline, as long as `is_active = true` and `is_cancelled = false`.
+- After verification, `update_campaign` is blocked so the verified title/description cannot be changed without re-review.
 
 ### 3) Funded (derived)
 - When `amount_raised >= funding_goal`, the campaign is considered funded.
@@ -43,8 +45,8 @@ Additional derived conditions used by the contract:
   - sets `is_cancelled = true`
   - sets `is_active = false`
 - Contributors can claim refunds via `claim_refund` after cancellation (if they contributed).
+- Successful refunds remove the contributor's stored contribution record instead of leaving a zero-value entry behind.
 
 ### 6) Expired / Failed (derived)
 - If the deadline passes and the campaign did not reach its goal (`Expired/Failed` derived condition), contributors can claim refunds via `claim_refund`.
 - The contract does not currently toggle `is_active` automatically when a deadline passes; "expired" is computed at call time using the ledger timestamp.
-

--- a/src/campaign_transfer_test.rs
+++ b/src/campaign_transfer_test.rs
@@ -1,0 +1,96 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_env<'a>() -> (Env, Address, Address, ProofOfHeartClient<'a>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+    client.init(&admin, &token_address, &300);
+
+    (env, admin, creator, client)
+}
+
+fn create_campaign(
+    env: &Env,
+    client: &ProofOfHeartClient<'_>,
+    creator: &Address,
+    title: &str,
+) -> u32 {
+    client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(env, title),
+        description: String::from_str(env, "Campaign transfer test"),
+        funding_goal: 1_000,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    })
+}
+
+#[test]
+fn campaign_transfer_reinitiate_replaces_pending_owner() {
+    let (env, _admin, creator, client) = setup_env();
+    let pending_one = Address::generate(&env);
+    let pending_two = Address::generate(&env);
+    let campaign_id = create_campaign(&env, &client, &creator, "Re-initiate transfer");
+
+    client.initiate_campaign_transfer(&campaign_id, &pending_one);
+    assert_eq!(
+        client.get_campaign(&campaign_id).pending_creator,
+        MaybePendingCreator::Some(pending_one)
+    );
+
+    client.initiate_campaign_transfer(&campaign_id, &pending_two);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.creator, creator);
+    assert_eq!(
+        campaign.pending_creator,
+        MaybePendingCreator::Some(pending_two.clone())
+    );
+
+    client.accept_campaign_transfer(&campaign_id);
+
+    let transferred = client.get_campaign(&campaign_id);
+    assert_eq!(transferred.creator, pending_two);
+    assert_eq!(transferred.pending_creator, MaybePendingCreator::None);
+}
+
+#[test]
+fn campaign_transfer_cancel_then_reinitiate_succeeds() {
+    let (env, _admin, creator, client) = setup_env();
+    let pending_one = Address::generate(&env);
+    let pending_two = Address::generate(&env);
+    let campaign_id = create_campaign(&env, &client, &creator, "Cancel and retry");
+
+    client.initiate_campaign_transfer(&campaign_id, &pending_one);
+    client.cancel_campaign_transfer(&campaign_id);
+    assert_eq!(
+        client.get_campaign(&campaign_id).pending_creator,
+        MaybePendingCreator::None
+    );
+
+    client.initiate_campaign_transfer(&campaign_id, &pending_two.clone());
+    client.accept_campaign_transfer(&campaign_id);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.creator, pending_two);
+    assert_eq!(campaign.pending_creator, MaybePendingCreator::None);
+}
+
+#[test]
+fn campaign_transfer_still_rejects_transfer_to_self() {
+    let (env, _admin, creator, client) = setup_env();
+    let campaign_id = create_campaign(&env, &client, &creator, "Self transfer");
+
+    let res = client.try_initiate_campaign_transfer(&campaign_id, &creator);
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidNewOwner);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,7 @@ impl ProofOfHeart {
         description: String,
     ) -> Result<(), Error> {
         let mut campaign = get_creator_campaign(&env, campaign_id)?;
+        require_unverified_campaign(&campaign)?;
 
         if campaign.amount_raised > 0 {
             return Err(Error::ValidationFailed);
@@ -557,7 +558,7 @@ impl ProofOfHeart {
         }
 
         bump_instance_ttl(&env);
-        set_contribution(&env, campaign_id, &contributor, 0);
+        remove_contribution(&env, campaign_id, &contributor);
         remove_revenue_claimed(&env, campaign_id, &contributor);
 
         let total_raised = get_total_raised_global(&env);
@@ -1083,11 +1084,7 @@ impl ProofOfHeart {
             return campaigns;
         }
 
-        let end = if start + limit > total_count {
-            total_count
-        } else {
-            start + limit
-        };
+        let end = start.saturating_add(limit).min(total_count);
 
         for id in (start + 1)..=end {
             if let Some(campaign) = get_campaign(&env, id) {
@@ -1220,6 +1217,10 @@ impl ProofOfHeart {
     }
 }
 
+#[cfg(test)]
+mod campaign_transfer_test;
+#[cfg(test)]
+mod pagination_test;
 #[cfg(test)]
 mod revenue_share_proptest;
 #[cfg(test)]

--- a/src/pagination_test.rs
+++ b/src/pagination_test.rs
@@ -16,12 +16,7 @@ fn setup_env<'a>() -> (Env, Address, Address, ProofOfHeartClient<'a>) {
     (env, admin, creator, client)
 }
 
-fn create_campaign(
-    env: &Env,
-    client: &ProofOfHeartClient<'_>,
-    creator: &Address,
-    idx: u32,
-) -> u32 {
+fn create_campaign(env: &Env, client: &ProofOfHeartClient<'_>, creator: &Address, idx: u32) -> u32 {
     client.create_campaign(&CreateCampaignParams {
         creator: creator.clone(),
         title: String::from_str(env, "Campaign"),

--- a/src/pagination_test.rs
+++ b/src/pagination_test.rs
@@ -1,0 +1,94 @@
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup_env<'a>() -> (Env, Address, Address, ProofOfHeartClient<'a>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+    client.init(&admin, &token_address, &300);
+
+    (env, admin, creator, client)
+}
+
+fn create_campaign(
+    env: &Env,
+    client: &ProofOfHeartClient<'_>,
+    creator: &Address,
+    idx: u32,
+) -> u32 {
+    client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(env, "Campaign"),
+        description: String::from_str(env, "Pagination test"),
+        funding_goal: 1_000 + idx as i128,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    })
+}
+
+#[test]
+fn list_campaigns_boundary_cases() {
+    let (env, _admin, creator, client) = setup_env();
+
+    for idx in 0..3 {
+        let id = create_campaign(&env, &client, &creator, idx);
+        assert_eq!(id, idx + 1);
+    }
+
+    let first_page = client.list_campaigns(&0, &2);
+    assert_eq!(first_page.len(), 2);
+    assert_eq!(first_page.get(0).unwrap().id, 1);
+    assert_eq!(first_page.get(1).unwrap().id, 2);
+
+    let all = client.list_campaigns(&0, &u32::MAX);
+    assert_eq!(all.len(), 3);
+    assert_eq!(all.get(0).unwrap().id, 1);
+    assert_eq!(all.get(2).unwrap().id, 3);
+
+    let total = client.get_campaign_count();
+    assert_eq!(client.list_campaigns(&total, &5).len(), 0);
+    assert_eq!(client.list_campaigns(&(total + 1), &5).len(), 0);
+    assert_eq!(client.list_campaigns(&0, &0).len(), 0);
+}
+
+#[test]
+fn list_active_campaigns_boundary_cases_and_sparse_results() {
+    let (env, _admin, creator, client) = setup_env();
+
+    for idx in 0..5 {
+        let _ = create_campaign(&env, &client, &creator, idx);
+    }
+
+    client.cancel_campaign(&2);
+    client.cancel_campaign(&4);
+
+    let first_page = client.list_active_campaigns(&0, &2);
+    assert_eq!(first_page.len(), 2);
+    assert_eq!(first_page.get(0).unwrap().id, 1);
+    assert_eq!(first_page.get(1).unwrap().id, 3);
+
+    let sparse_page = client.list_active_campaigns(&1, &2);
+    assert_eq!(sparse_page.len(), 2);
+    assert_eq!(sparse_page.get(0).unwrap().id, 3);
+    assert_eq!(sparse_page.get(1).unwrap().id, 5);
+
+    let all = client.list_active_campaigns(&0, &u32::MAX);
+    assert_eq!(all.len(), 3);
+    assert_eq!(all.get(0).unwrap().id, 1);
+    assert_eq!(all.get(1).unwrap().id, 3);
+    assert_eq!(all.get(2).unwrap().id, 5);
+
+    let total = client.get_campaign_count();
+    assert_eq!(client.list_active_campaigns(&total, &5).len(), 0);
+    assert_eq!(client.list_active_campaigns(&(total + 1), &5).len(), 0);
+    assert_eq!(client.list_active_campaigns(&0, &0).len(), 0);
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -192,6 +192,12 @@ pub fn set_contribution(env: &Env, campaign_id: u32, contributor: &Address, amou
         .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
 }
 
+/// Removes a contributor's contribution record entirely.
+pub fn remove_contribution(env: &Env, campaign_id: u32, contributor: &Address) {
+    let key = DataKey::Contribution(campaign_id, contributor.clone());
+    env.storage().persistent().remove(&key);
+}
+
 // ── Revenue ───────────────────────────────────────────────────────────────────
 
 /// Returns the revenue pool balance for a campaign, extending TTL if non-zero.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1282,6 +1282,31 @@ fn test_update_campaign_description_not_found() {
 }
 
 #[test]
+fn test_update_campaign_rejects_verified_campaign_even_before_contributions() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Verified title").clone(),
+        String::from_str(&env, "Verified description").clone(),
+        1_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    let res = client.try_update_campaign(
+        &campaign_id,
+        &String::from_str(&env, "Changed title"),
+        &String::from_str(&env, "Changed description"),
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+}
+
+#[test]
 fn test_campaign_ownership_transfer_flow() {
     let (env, _admin, creator, contributor1, contributor2, _, _, client) = setup_env();
     let new_creator = contributor1;
@@ -2587,6 +2612,45 @@ fn test_claim_refund_clears_existing_revenue_claimed_key() {
     client.claim_refund(&campaign_id, &contributor1);
 
     assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
+}
+
+#[test]
+fn test_claim_refund_removes_contribution_storage_key() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5_000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Refund storage cleanup").clone(),
+        String::from_str(&env, "Contribution key should be removed").clone(),
+        5_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1_000);
+    client.cancel_campaign(&campaign_id);
+
+    env.as_contract(&client.address, || {
+        assert!(
+            env.storage()
+                .persistent()
+                .has(&DataKey::Contribution(campaign_id, contributor1.clone()))
+        );
+    });
+
+    client.claim_refund(&campaign_id, &contributor1);
+
+    env.as_contract(&client.address, || {
+        assert!(
+            !env.storage()
+                .persistent()
+                .has(&DataKey::Contribution(campaign_id, contributor1.clone()))
+        );
+    });
 }
 
 // ── Issue 3: Fuzz/Integration tests for vote_on_campaign ─────────────────────

--- a/src/test.rs
+++ b/src/test.rs
@@ -2635,21 +2635,19 @@ fn test_claim_refund_removes_contribution_storage_key() {
     client.cancel_campaign(&campaign_id);
 
     env.as_contract(&client.address, || {
-        assert!(
-            env.storage()
-                .persistent()
-                .has(&DataKey::Contribution(campaign_id, contributor1.clone()))
-        );
+        assert!(env
+            .storage()
+            .persistent()
+            .has(&DataKey::Contribution(campaign_id, contributor1.clone())));
     });
 
     client.claim_refund(&campaign_id, &contributor1);
 
     env.as_contract(&client.address, || {
-        assert!(
-            !env.storage()
-                .persistent()
-                .has(&DataKey::Contribution(campaign_id, contributor1.clone()))
-        );
+        assert!(!env
+            .storage()
+            .persistent()
+            .has(&DataKey::Contribution(campaign_id, contributor1.clone())));
     });
 }
 

--- a/test_snapshots/test/test_cancel_and_refund.1.json
+++ b/test_snapshots/test/test_cancel_and_refund.1.json
@@ -108,37 +108,86 @@
               "function_name": "create_campaign",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Failed Idea"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 5000
-                  }
-                },
-                {
-                  "u64": 10
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "bool": false
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Desc"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "duration_days"
+                      },
+                      "val": {
+                        "u64": 10
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "funding_goal"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 5000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "has_revenue_sharing"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_contribution_per_user"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revenue_share_percentage"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "title"
+                      },
+                      "val": {
+                        "string": "Failed Idea"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -964,114 +1013,6 @@
                       }
                     }
                   ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Contribution"
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Contribution"
-                    },
-                    {
-                      "u32": 1
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Contribution"
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Contribution"
-                    },
-                    {
-                      "u32": 1
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
                 }
               }
             },
@@ -2127,38 +2068,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Failed Idea"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 5000
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 0
                   }
                 },
                 {
-                  "u64": 10
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Desc"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 10
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 5000
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Failed Idea"
                   }
                 }
               ]

--- a/test_snapshots/test/test_contribute_and_withdraw_success.1.json
+++ b/test_snapshots/test/test_contribute_and_withdraw_success.1.json
@@ -83,37 +83,86 @@
               "function_name": "create_campaign",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Code Camp"
-                },
-                {
-                  "string": "Learn Rust"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
-                  }
-                },
-                {
-                  "u64": 30
-                },
-                {
-                  "u32": 2
-                },
-                {
-                  "bool": false
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Learn Rust"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "duration_days"
+                      },
+                      "val": {
+                        "u64": 30
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "funding_goal"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "has_revenue_sharing"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_contribution_per_user"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revenue_share_percentage"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "title"
+                      },
+                      "val": {
+                        "string": "Code Camp"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1806,38 +1855,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Code Camp"
-                },
-                {
-                  "string": "Learn Rust"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 2
                   }
                 },
                 {
-                  "u64": 30
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 2
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Learn Rust"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 30
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 1000
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Code Camp"
                   }
                 }
               ]

--- a/test_snapshots/test/test_create_and_validation.1.json
+++ b/test_snapshots/test/test_create_and_validation.1.json
@@ -62,37 +62,86 @@
               "function_name": "create_campaign",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 2000
-                  }
-                },
-                {
-                  "u64": 30
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "bool": true
-                },
-                {
-                  "u32": 1500
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Teaching science to kids"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "duration_days"
+                      },
+                      "val": {
+                        "u64": 30
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "funding_goal"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 2000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "has_revenue_sharing"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_contribution_per_user"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revenue_share_percentage"
+                      },
+                      "val": {
+                        "u32": 1500
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "title"
+                      },
+                      "val": {
+                        "string": "Science Book"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -1077,38 +1126,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 3
                   }
                 },
                 {
-                  "u64": 30
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 3
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Teaching science to kids"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 30
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Science Book"
                   }
                 }
               ]
@@ -1196,37 +1290,86 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    },
-                    {
-                      "string": "Science Book"
-                    },
-                    {
-                      "string": "Teaching science to kids"
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 0
-                      }
-                    },
-                    {
-                      "u64": 30
-                    },
-                    {
-                      "u32": 3
-                    },
-                    {
-                      "bool": false
-                    },
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 0
-                      }
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "category"
+                          },
+                          "val": {
+                            "u32": 3
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "creator"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "description"
+                          },
+                          "val": {
+                            "string": "Teaching science to kids"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "duration_days"
+                          },
+                          "val": {
+                            "u64": 30
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "funding_goal"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 0
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "has_revenue_sharing"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "max_contribution_per_user"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 0
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "revenue_share_percentage"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "title"
+                          },
+                          "val": {
+                            "string": "Science Book"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1256,38 +1399,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 3
                   }
                 },
                 {
-                  "u64": 0
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 3
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Teaching science to kids"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 500
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Science Book"
                   }
                 }
               ]
@@ -1375,37 +1563,86 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    },
-                    {
-                      "string": "Science Book"
-                    },
-                    {
-                      "string": "Teaching science to kids"
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 500
-                      }
-                    },
-                    {
-                      "u64": 0
-                    },
-                    {
-                      "u32": 3
-                    },
-                    {
-                      "bool": false
-                    },
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 0
-                      }
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "category"
+                          },
+                          "val": {
+                            "u32": 3
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "creator"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "description"
+                          },
+                          "val": {
+                            "string": "Teaching science to kids"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "duration_days"
+                          },
+                          "val": {
+                            "u64": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "funding_goal"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 500
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "has_revenue_sharing"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "max_contribution_per_user"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 0
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "revenue_share_percentage"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "title"
+                          },
+                          "val": {
+                            "string": "Science Book"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1435,38 +1672,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 3
                   }
                 },
                 {
-                  "u64": 400
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 3
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Teaching science to kids"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 400
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 500
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Science Book"
                   }
                 }
               ]
@@ -1554,37 +1836,86 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    },
-                    {
-                      "string": "Science Book"
-                    },
-                    {
-                      "string": "Teaching science to kids"
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 500
-                      }
-                    },
-                    {
-                      "u64": 400
-                    },
-                    {
-                      "u32": 3
-                    },
-                    {
-                      "bool": false
-                    },
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 0
-                      }
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "category"
+                          },
+                          "val": {
+                            "u32": 3
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "creator"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "description"
+                          },
+                          "val": {
+                            "string": "Teaching science to kids"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "duration_days"
+                          },
+                          "val": {
+                            "u64": 400
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "funding_goal"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 500
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "has_revenue_sharing"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "max_contribution_per_user"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 0
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "revenue_share_percentage"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "title"
+                          },
+                          "val": {
+                            "string": "Science Book"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1614,38 +1945,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 2
                   }
                 },
                 {
-                  "u64": 30
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 2
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Teaching science to kids"
+                  }
                 },
                 {
-                  "bool": true
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 30
+                  }
                 },
                 {
-                  "u32": 1000
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 500
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": true
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 1000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Science Book"
                   }
                 }
               ]
@@ -1733,37 +2109,86 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    },
-                    {
-                      "string": "Science Book"
-                    },
-                    {
-                      "string": "Teaching science to kids"
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 500
-                      }
-                    },
-                    {
-                      "u64": 30
-                    },
-                    {
-                      "u32": 2
-                    },
-                    {
-                      "bool": true
-                    },
-                    {
-                      "u32": 1000
-                    },
-                    {
-                      "i128": {
-                        "hi": 0,
-                        "lo": 0
-                      }
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "category"
+                          },
+                          "val": {
+                            "u32": 2
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "creator"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "description"
+                          },
+                          "val": {
+                            "string": "Teaching science to kids"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "duration_days"
+                          },
+                          "val": {
+                            "u64": 30
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "funding_goal"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 500
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "has_revenue_sharing"
+                          },
+                          "val": {
+                            "bool": true
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "max_contribution_per_user"
+                          },
+                          "val": {
+                            "i128": {
+                              "hi": 0,
+                              "lo": 0
+                            }
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "revenue_share_percentage"
+                          },
+                          "val": {
+                            "u32": 1000
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "title"
+                          },
+                          "val": {
+                            "string": "Science Book"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -1793,38 +2218,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Science Book"
-                },
-                {
-                  "string": "Teaching science to kids"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 2000
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 1
                   }
                 },
                 {
-                  "u64": 30
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 1
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Teaching science to kids"
+                  }
                 },
                 {
-                  "bool": true
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 30
+                  }
                 },
                 {
-                  "u32": 1500
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 2000
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": true
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 1500
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Science Book"
                   }
                 }
               ]

--- a/test_snapshots/test/test_failure_states.1.json
+++ b/test_snapshots/test/test_failure_states.1.json
@@ -83,37 +83,86 @@
               "function_name": "create_campaign",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Deadline Test"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
-                  }
-                },
-                {
-                  "u64": 2
-                },
-                {
-                  "u32": 2
-                },
-                {
-                  "bool": false
-                },
-                {
-                  "u32": 0
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Desc"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "duration_days"
+                      },
+                      "val": {
+                        "u64": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "funding_goal"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "has_revenue_sharing"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_contribution_per_user"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revenue_share_percentage"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "title"
+                      },
+                      "val": {
+                        "string": "Deadline Test"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -715,60 +764,6 @@
                       }
                     }
                   ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Contribution"
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Contribution"
-                    },
-                    {
-                      "u32": 1
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
                 }
               }
             },
@@ -1662,38 +1657,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Deadline Test"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 2
                   }
                 },
                 {
-                  "u64": 2
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 2
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Desc"
+                  }
                 },
                 {
-                  "bool": false
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 2
+                  }
                 },
                 {
-                  "u32": 0
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 1000
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": false
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Deadline Test"
                   }
                 }
               ]

--- a/test_snapshots/test/test_pull_based_revenue_distribution.1.json
+++ b/test_snapshots/test/test_pull_based_revenue_distribution.1.json
@@ -133,37 +133,86 @@
               "function_name": "create_campaign",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Next Gen AI"
-                },
-                {
-                  "string": "Build AI"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 2000
-                  }
-                },
-                {
-                  "u64": 30
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "bool": true
-                },
-                {
-                  "u32": 2000
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
-                  }
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "category"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": "Build AI"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "duration_days"
+                      },
+                      "val": {
+                        "u64": 30
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "funding_goal"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 2000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "has_revenue_sharing"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "max_contribution_per_user"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "revenue_share_percentage"
+                      },
+                      "val": {
+                        "u32": 2000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "title"
+                      },
+                      "val": {
+                        "string": "Next Gen AI"
+                      }
+                    }
+                  ]
                 }
               ]
             }
@@ -2807,38 +2856,83 @@
               }
             ],
             "data": {
-              "vec": [
+              "map": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Next Gen AI"
-                },
-                {
-                  "string": "Build AI"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 2000
+                  "key": {
+                    "symbol": "category"
+                  },
+                  "val": {
+                    "u32": 1
                   }
                 },
                 {
-                  "u64": 30
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
                 },
                 {
-                  "u32": 1
+                  "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": "Build AI"
+                  }
                 },
                 {
-                  "bool": true
+                  "key": {
+                    "symbol": "duration_days"
+                  },
+                  "val": {
+                    "u64": 30
+                  }
                 },
                 {
-                  "u32": 2000
+                  "key": {
+                    "symbol": "funding_goal"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 2000
+                    }
+                  }
                 },
                 {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 0
+                  "key": {
+                    "symbol": "has_revenue_sharing"
+                  },
+                  "val": {
+                    "bool": true
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "max_contribution_per_user"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "revenue_share_percentage"
+                  },
+                  "val": {
+                    "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "title"
+                  },
+                  "val": {
+                    "string": "Next Gen AI"
                   }
                 }
               ]


### PR DESCRIPTION
## Summary
- block `update_campaign` once a campaign is verified
- remove contribution storage on refund instead of zeroing it
- add campaign transfer edge-case tests
- add pagination boundary tests for campaign listings

Closes #184
Closes #219
Closes #171
Closes #208
