### PR TITLE
Refactor: implement list caps, kill switch, clippy fix, and verificat…

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,4 +67,6 @@ pub enum Error {
     Overflow = 30,
     /// The provided address is not a valid SEP-41 token contract.
     InvalidTokenContract = 31,
+    /// Campaign creation is disabled by the admin.
+    CreationDisabled = 32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ const PLATFORM_FEE_MAX_BPS: u32 = 1000; // 10%
 const REVENUE_SHARE_MAX_BPS: u32 = 5000; // 50%
 const AUTO_PAUSE_SINGLE_CONTRIBUTION_BPS_THRESHOLD: i128 = 20000; // 200%
 const AUTO_PAUSE_BURST_THRESHOLD: u32 = 10;
+const LIST_MAX_LIMIT: u32 = 50;
 
 mod errors;
 mod storage;
@@ -99,7 +100,6 @@ fn calculate_deadline(current_time: u64, duration_days: u64) -> Result<u64, Erro
 #[contract]
 pub struct ProofOfHeart;
 
-#[allow(clippy::too_many_arguments)]
 #[contractimpl]
 impl ProofOfHeart {
     fn token_client(env: &Env) -> token::Client<'_> {
@@ -196,9 +196,13 @@ impl ProofOfHeart {
     ///
     /// # Authorization
     /// Requires `creator.require_auth()`.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_campaign(env: Env, params: CreateCampaignParams) -> Result<u32, Error> {
         params.creator.require_auth();
         Self::require_not_paused(&env)?;
+        if get_creation_disabled(&env) {
+            return Err(Error::CreationDisabled);
+        }
 
         let CreateCampaignParams {
             creator,
@@ -924,6 +928,25 @@ impl ProofOfHeart {
             .unwrap_or(false)
     }
 
+    /// Disables new campaign creation (admin-only kill switch).
+    ///
+    /// # Authorization
+    /// Requires the stored admin's authorization.
+    pub fn set_creation_disabled(env: Env, disabled: bool) -> Result<(), Error> {
+        let admin = get_admin(&env);
+        assert_admin(&env, &admin)?;
+        bump_instance_ttl(&env);
+        set_creation_disabled(&env, disabled);
+        env.events()
+            .publish(("creation_disabled_updated", admin), disabled);
+        Ok(())
+    }
+
+    /// Returns whether campaign creation is disabled.
+    pub fn is_creation_disabled(env: Env) -> bool {
+        get_creation_disabled(&env)
+    }
+
     /// Cast a vote on a campaign (approve or reject) to move it towards community verification.
     ///
     /// # Authorization
@@ -1276,6 +1299,8 @@ impl ProofOfHeart {
     /// - `start` is the last campaign ID already seen (exclusive cursor).
     /// - pass `start = 0` for the first page.
     /// - pass the last returned campaign ID as `start` for the next page.
+    ///
+    /// Caps the limit at LIST_MAX_LIMIT (50) to prevent pathological calls.
     pub fn list_campaigns(env: Env, start: u32, limit: u32) -> soroban_sdk::Vec<Campaign> {
         let total_count = get_campaign_count(&env);
         let mut campaigns = soroban_sdk::Vec::new(&env);
@@ -1284,7 +1309,8 @@ impl ProofOfHeart {
             return campaigns;
         }
 
-        let end = start.saturating_add(limit).min(total_count);
+        let capped_limit = limit.min(LIST_MAX_LIMIT);
+        let end = start.saturating_add(capped_limit).min(total_count);
 
         for id in (start + 1)..=end {
             if let Some(campaign) = get_campaign(&env, id) {
@@ -1301,6 +1327,8 @@ impl ProofOfHeart {
     /// CRITICAL FIX for issue #176 (DoS risk):
     /// Caps the scan window to MAX_SCAN_WINDOW to prevent unbounded iteration.
     /// Returns a continuation cursor when the limit cannot be satisfied within the scan window.
+    ///
+    /// Also Caps the limit at LIST_MAX_LIMIT (50) to prevent pathological calls.
     ///
     /// # Returns
     /// A tuple of (campaigns, next_cursor) where:
@@ -1321,11 +1349,12 @@ impl ProofOfHeart {
         // Cap scan window to prevent DoS - fixes issue #176
         // Worst case: scans at most MAX_SCAN_WINDOW storage reads
         const MAX_SCAN_WINDOW: u32 = 200;
+        let capped_limit = limit.min(LIST_MAX_LIMIT);
         let mut collected = 0u32;
         let mut current_id = start + 1;
         let mut next_cursor = 0u32;
 
-        while collected < limit && current_id <= total_count {
+        while collected < capped_limit && current_id <= total_count {
             if let Some(campaign) = get_campaign(&env, current_id) {
                 if campaign.is_active && !campaign.is_cancelled {
                     campaigns.push_back(campaign);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -75,6 +75,10 @@ pub enum DataKey {
     WithdrawReservePercentage,
     /// Held reserve for a campaign, keyed by campaign ID.
     CampaignReserve(u32),
+    /// Whether campaign creation is disabled.
+    CreationDisabled,
+    /// Contributor count for a campaign.
+    ContributorCount(u32),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -209,6 +213,36 @@ pub fn set_lifetime_contribution(env: &Env, campaign_id: u32, contributor: &Addr
 pub fn remove_contribution(env: &Env, campaign_id: u32, contributor: &Address) {
     let key = DataKey::Contribution(campaign_id, contributor.clone());
     env.storage().persistent().remove(&key);
+}
+
+// ── Contributor count ───────────────────────────────────────────────────────────
+
+pub fn get_contributor_count(env: &Env, campaign_id: u32) -> u32 {
+    let key = DataKey::ContributorCount(campaign_id);
+    env.storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(0)
+}
+
+pub fn set_contributor_count(env: &Env, campaign_id: u32, count: u32) {
+    let key = DataKey::ContributorCount(campaign_id);
+    env.storage().persistent().set(&key, &count);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn increment_contributor_count(env: &Env, campaign_id: u32) {
+    let count = get_contributor_count(env, campaign_id);
+    set_contributor_count(env, campaign_id, count + 1);
+}
+
+pub fn decrement_contributor_count(env: &Env, campaign_id: u32) {
+    let count = get_contributor_count(env, campaign_id);
+    if count > 0 {
+        set_contributor_count(env, campaign_id, count - 1);
+    }
 }
 
 // ── Revenue ───────────────────────────────────────────────────────────────────
@@ -558,4 +592,19 @@ pub fn set_campaign_reserve(env: &Env, campaign_id: u32, reserve: &CampaignReser
     env.storage()
         .persistent()
         .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+// ── Creation disabled flag ───────────────────────────────────────────────────
+
+pub fn get_creation_disabled(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::CreationDisabled)
+        .unwrap_or(false)
+}
+
+pub fn set_creation_disabled(env: &Env, disabled: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CreationDisabled, &disabled);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -663,6 +663,73 @@ fn test_admin_verify_campaign_success() {
 }
 
 #[test]
+fn test_update_campaign_fails_after_verification() {
+    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    let title = String::from_str(&env, "Original Title");
+    let desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.verify_campaign(&campaign_id);
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(campaign.is_verified);
+
+    let new_title = String::from_str(&env, "New Title");
+    let new_desc = String::from_str(&env, "New Description");
+    let res = client.try_update_campaign(&campaign_id, &new_title, &new_desc);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+}
+
+#[test]
+fn test_update_campaign_fails_after_verification_with_votes() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let title = String::from_str(&env, "Original Title");
+    let desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &true);
+
+    client.verify_campaign_with_votes(&campaign_id);
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(campaign.is_verified);
+
+    let new_title = String::from_str(&env, "New Title");
+    let new_desc = String::from_str(&env, "New Description");
+    let res = client.try_update_campaign(&campaign_id, &new_title, &new_desc);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+}
+
+#[test]
 fn test_admin_verify_campaign_duplicate_attempt() {
     let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
         setup_env();


### PR DESCRIPTION
…ion tests

Add LIST_MAX_LIMIT (50) cap to list_campaigns and list_active_campaigns
 Add CreationDisabled flag with admin getter/setter kill switch
 Move #[allow(clippy::too_many_arguments)] from impl to create_campaign only
 Add tests for update_campaign regression after verification

Closes #228
Closes #204
Closes #222
Closes #207