### PR TITLE
feat: add max funding goal cap (#195) and create_campaign fuzz tests

### DIFF
--- a/src/create_campaign_proptest.rs
+++ b/src/create_campaign_proptest.rs
@@ -1,0 +1,252 @@
+//! Property-based fuzz tests for `create_campaign` validation inputs.
+//!
+//! These tests exercise the pure validation logic (no contract environment
+//! required) to uncover edge-case regressions in:
+//!
+//! * `funding_goal` bounds (positive, min, max cap)
+//! * `duration_days` bounds
+//! * `revenue_share_percentage` bounds
+//! * `max_contribution_per_user` sign check
+
+use proptest::prelude::*;
+
+// ── Mirror the validation constants from lib.rs ──────────────────────────────
+
+const CAMPAIGN_FUNDING_GOAL_MIN: i128 = 100_000;
+const CAMPAIGN_FUNDING_GOAL_MAX: i128 = 1_000_000_000_000_000; // 10^15
+const CAMPAIGN_DURATION_MIN_DAYS: u64 = 1;
+const CAMPAIGN_DURATION_MAX_DAYS: u64 = 365;
+const REVENUE_SHARE_MAX_BPS: u32 = 5000;
+
+// ── Pure validation helpers (mirror lib.rs logic) ────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ValidationError {
+    FundingGoalMustBePositive,
+    FundingGoalTooLow,
+    FundingGoalTooHigh,
+    InvalidDuration,
+    InvalidRevenueShare,
+    NegativeContributionCap,
+}
+
+fn validate_funding_goal(goal: i128, min: i128, max: i128) -> Result<(), ValidationError> {
+    if goal <= 0 {
+        return Err(ValidationError::FundingGoalMustBePositive);
+    }
+    if goal < min {
+        return Err(ValidationError::FundingGoalTooLow);
+    }
+    if goal > max {
+        return Err(ValidationError::FundingGoalTooHigh);
+    }
+    Ok(())
+}
+
+fn validate_duration(days: u64) -> Result<(), ValidationError> {
+    if !(CAMPAIGN_DURATION_MIN_DAYS..=CAMPAIGN_DURATION_MAX_DAYS).contains(&days) {
+        return Err(ValidationError::InvalidDuration);
+    }
+    Ok(())
+}
+
+fn validate_revenue_share(has_revenue_sharing: bool, bps: u32) -> Result<(), ValidationError> {
+    if bps > REVENUE_SHARE_MAX_BPS {
+        return Err(ValidationError::InvalidRevenueShare);
+    }
+    if has_revenue_sharing && bps == 0 {
+        return Err(ValidationError::InvalidRevenueShare);
+    }
+    Ok(())
+}
+
+fn validate_max_contribution(cap: i128) -> Result<(), ValidationError> {
+    if cap < 0 {
+        return Err(ValidationError::NegativeContributionCap);
+    }
+    Ok(())
+}
+
+// ── Properties ───────────────────────────────────────────────────────────────
+
+proptest! {
+    /// Any goal in [min, max] must pass.
+    #[test]
+    fn prop_funding_goal_valid_range_always_passes(
+        goal in CAMPAIGN_FUNDING_GOAL_MIN..=CAMPAIGN_FUNDING_GOAL_MAX,
+    ) {
+        prop_assert!(
+            validate_funding_goal(goal, CAMPAIGN_FUNDING_GOAL_MIN, CAMPAIGN_FUNDING_GOAL_MAX).is_ok(),
+            "goal {goal} in valid range should pass"
+        );
+    }
+
+    /// Zero or negative goals must always be rejected.
+    #[test]
+    fn prop_non_positive_funding_goal_rejected(goal in i128::MIN..=0i128) {
+        let err = validate_funding_goal(goal, CAMPAIGN_FUNDING_GOAL_MIN, CAMPAIGN_FUNDING_GOAL_MAX)
+            .unwrap_err();
+        prop_assert_eq!(err, ValidationError::FundingGoalMustBePositive);
+    }
+
+    /// Goals below min (but positive) must return TooLow.
+    #[test]
+    fn prop_funding_goal_below_min_rejected(goal in 1i128..CAMPAIGN_FUNDING_GOAL_MIN) {
+        let err = validate_funding_goal(goal, CAMPAIGN_FUNDING_GOAL_MIN, CAMPAIGN_FUNDING_GOAL_MAX)
+            .unwrap_err();
+        prop_assert_eq!(err, ValidationError::FundingGoalTooLow);
+    }
+
+    /// Goals above max must return TooHigh.
+    #[test]
+    fn prop_funding_goal_above_max_rejected(
+        goal in (CAMPAIGN_FUNDING_GOAL_MAX + 1)..=i128::MAX,
+    ) {
+        let err = validate_funding_goal(goal, CAMPAIGN_FUNDING_GOAL_MIN, CAMPAIGN_FUNDING_GOAL_MAX)
+            .unwrap_err();
+        prop_assert_eq!(err, ValidationError::FundingGoalTooHigh);
+    }
+
+    /// Duration in [1, 365] must pass.
+    #[test]
+    fn prop_valid_duration_passes(days in CAMPAIGN_DURATION_MIN_DAYS..=CAMPAIGN_DURATION_MAX_DAYS) {
+        prop_assert!(validate_duration(days).is_ok());
+    }
+
+    /// Duration > 365 must fail.
+    #[test]
+    fn prop_duration_above_max_rejected(days in (CAMPAIGN_DURATION_MAX_DAYS + 1)..=u64::MAX) {
+        prop_assert_eq!(validate_duration(days).unwrap_err(), ValidationError::InvalidDuration);
+    }
+
+    /// Revenue share bps in (0, 5000] with flag=true must pass.
+    #[test]
+    fn prop_valid_revenue_share_passes(bps in 1u32..=REVENUE_SHARE_MAX_BPS) {
+        prop_assert!(validate_revenue_share(true, bps).is_ok());
+    }
+
+    /// bps > 5000 must always fail regardless of flag.
+    #[test]
+    fn prop_revenue_share_above_max_rejected(bps in (REVENUE_SHARE_MAX_BPS + 1)..=u32::MAX) {
+        prop_assert_eq!(
+            validate_revenue_share(true, bps).unwrap_err(),
+            ValidationError::InvalidRevenueShare
+        );
+        prop_assert_eq!(
+            validate_revenue_share(false, bps).unwrap_err(),
+            ValidationError::InvalidRevenueShare
+        );
+    }
+
+    /// Revenue sharing disabled with any bps in [0, 5000] must pass.
+    #[test]
+    fn prop_revenue_share_disabled_any_valid_bps_passes(bps in 0u32..=REVENUE_SHARE_MAX_BPS) {
+        prop_assert!(validate_revenue_share(false, bps).is_ok());
+    }
+
+    /// Non-negative contribution cap must pass.
+    #[test]
+    fn prop_non_negative_contribution_cap_passes(cap in 0i128..=i128::MAX) {
+        prop_assert!(validate_max_contribution(cap).is_ok());
+    }
+
+    /// Negative contribution cap must fail.
+    #[test]
+    fn prop_negative_contribution_cap_rejected(cap in i128::MIN..=-1i128) {
+        prop_assert_eq!(
+            validate_max_contribution(cap).unwrap_err(),
+            ValidationError::NegativeContributionCap
+        );
+    }
+
+    /// Admin-raised cap: a goal previously above default max is valid under the new cap.
+    #[test]
+    fn prop_admin_raised_cap_allows_higher_goals(
+        extra in 1i128..=CAMPAIGN_FUNDING_GOAL_MAX,
+    ) {
+        let goal = CAMPAIGN_FUNDING_GOAL_MAX + extra;
+        let raised_max = goal; // admin sets cap exactly to this goal
+        prop_assert!(
+            validate_funding_goal(goal, CAMPAIGN_FUNDING_GOAL_MIN, raised_max).is_ok(),
+            "goal {goal} should pass under raised cap {raised_max}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_funding_goal_boundary_exact_min() {
+        assert!(validate_funding_goal(
+            CAMPAIGN_FUNDING_GOAL_MIN,
+            CAMPAIGN_FUNDING_GOAL_MIN,
+            CAMPAIGN_FUNDING_GOAL_MAX
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_funding_goal_boundary_exact_max() {
+        assert!(validate_funding_goal(
+            CAMPAIGN_FUNDING_GOAL_MAX,
+            CAMPAIGN_FUNDING_GOAL_MIN,
+            CAMPAIGN_FUNDING_GOAL_MAX
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_funding_goal_one_above_max() {
+        assert_eq!(
+            validate_funding_goal(
+                CAMPAIGN_FUNDING_GOAL_MAX + 1,
+                CAMPAIGN_FUNDING_GOAL_MIN,
+                CAMPAIGN_FUNDING_GOAL_MAX
+            )
+            .unwrap_err(),
+            ValidationError::FundingGoalTooHigh
+        );
+    }
+
+    #[test]
+    fn test_funding_goal_one_below_min() {
+        assert_eq!(
+            validate_funding_goal(
+                CAMPAIGN_FUNDING_GOAL_MIN - 1,
+                CAMPAIGN_FUNDING_GOAL_MIN,
+                CAMPAIGN_FUNDING_GOAL_MAX
+            )
+            .unwrap_err(),
+            ValidationError::FundingGoalTooLow
+        );
+    }
+
+    #[test]
+    fn test_admin_can_raise_cap() {
+        let raised_max = CAMPAIGN_FUNDING_GOAL_MAX * 2;
+        assert!(validate_funding_goal(
+            CAMPAIGN_FUNDING_GOAL_MAX + 1,
+            CAMPAIGN_FUNDING_GOAL_MIN,
+            raised_max
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_duration_zero_rejected() {
+        assert_eq!(
+            validate_duration(0).unwrap_err(),
+            ValidationError::InvalidDuration
+        );
+    }
+
+    #[test]
+    fn test_revenue_share_enabled_zero_bps_rejected() {
+        assert_eq!(
+            validate_revenue_share(true, 0).unwrap_err(),
+            ValidationError::InvalidRevenueShare
+        );
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,4 +75,6 @@ pub enum Error {
     AdminVerificationConflict = 34,
     /// Community verification was attempted on an already verified campaign.
     CommunityVerificationConflict = 35,
+    /// The funding goal exceeds the configured maximum (anti-spam cap).
+    FundingGoalTooHigh = 36,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ const CAMPAIGN_DESCRIPTION_MAX_LEN: u32 = 1000;
 const CAMPAIGN_DURATION_MIN_DAYS: u64 = 1;
 const CAMPAIGN_DURATION_MAX_DAYS: u64 = 365;
 const CAMPAIGN_FUNDING_GOAL_MIN: i128 = 100_000;
+const CAMPAIGN_FUNDING_GOAL_MAX: i128 = 1_000_000_000_000_000; // 10^15
 const PLATFORM_FEE_MAX_BPS: u32 = 1000; // 10%
 const REVENUE_SHARE_MAX_BPS: u32 = 5000; // 50%
 const AUTO_PAUSE_SINGLE_CONTRIBUTION_BPS_THRESHOLD: i128 = 20000; // 200%
@@ -223,6 +224,9 @@ impl ProofOfHeart {
         }
         if funding_goal < get_min_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MIN) {
             return Err(Error::FundingGoalTooLow);
+        }
+        if funding_goal > get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX) {
+            return Err(Error::FundingGoalTooHigh);
         }
         if !(CAMPAIGN_DURATION_MIN_DAYS..=CAMPAIGN_DURATION_MAX_DAYS).contains(&duration_days) {
             return Err(Error::InvalidDuration);
@@ -1330,6 +1334,42 @@ impl ProofOfHeart {
         Ok(())
     }
 
+    /// Returns the current maximum funding goal cap for new campaigns.
+    pub fn get_max_campaign_funding_goal(env: Env) -> i128 {
+        get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX)
+    }
+
+    /// Updates the maximum funding goal cap for newly created campaigns.
+    ///
+    /// # Authorization
+    /// Requires `admin.require_auth()`.
+    pub fn set_max_campaign_funding_goal(
+        env: Env,
+        admin: Address,
+        max_goal: i128,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        Self::require_not_paused(&env)?;
+        if admin != get_admin(&env) {
+            return Err(Error::NotAuthorized);
+        }
+        if max_goal <= 0 {
+            return Err(Error::FundingGoalMustBePositive);
+        }
+        if max_goal < get_min_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MIN) {
+            return Err(Error::ValidationFailed);
+        }
+
+        let old_max_goal = get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX);
+        bump_instance_ttl(&env);
+        set_max_campaign_funding_goal(&env, max_goal);
+        env.events().publish(
+            ("max_campaign_funding_goal_updated",),
+            (old_max_goal, max_goal),
+        );
+        Ok(())
+    }
+
     /// Returns the minimum token balance required to vote on campaigns.
     pub fn get_min_voting_balance(env: Env) -> i128 {
         get_min_voting_balance(&env)
@@ -1627,6 +1667,8 @@ mod admin_transfer_test;
 mod benchmark_test;
 #[cfg(test)]
 mod campaign_transfer_test;
+#[cfg(test)]
+mod create_campaign_proptest;
 #[cfg(test)]
 mod lifecycle_events_test;
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -25,6 +25,8 @@ pub enum DataKey {
     PlatformFee,
     /// Minimum funding goal required for new campaigns.
     MinCampaignFundingGoal,
+    /// Maximum funding goal allowed for new campaigns (anti-spam cap).
+    MaxCampaignFundingGoal,
     /// Total number of campaigns ever created.
     CampaignCount,
     /// Campaign data, keyed by campaign ID.
@@ -192,6 +194,21 @@ pub fn set_min_campaign_funding_goal(env: &Env, min_goal: i128) {
     env.storage()
         .instance()
         .set(&DataKey::MinCampaignFundingGoal, &min_goal);
+}
+
+/// Returns the maximum funding goal, falling back to `default` if not set.
+pub fn get_max_campaign_funding_goal(env: &Env, default: i128) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MaxCampaignFundingGoal)
+        .unwrap_or(default)
+}
+
+/// Stores the maximum funding goal.
+pub fn set_max_campaign_funding_goal(env: &Env, max_goal: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxCampaignFundingGoal, &max_goal);
 }
 
 // ── Contributions ─────────────────────────────────────────────────────────────

--- a/src/test.rs
+++ b/src/test.rs
@@ -303,6 +303,67 @@ fn test_min_campaign_funding_goal_boundary_and_admin_update() {
 }
 
 #[test]
+fn test_max_campaign_funding_goal_boundary_and_admin_update() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) =
+        setup_env_with_default_min();
+
+    assert_eq!(
+        client.get_max_campaign_funding_goal(),
+        CAMPAIGN_FUNDING_GOAL_MAX
+    );
+
+    let title = String::from_str(&env, "Max Goal");
+    let desc = String::from_str(&env, "Checks funding goal ceiling");
+
+    // Exactly at the cap must succeed.
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        CAMPAIGN_FUNDING_GOAL_MAX,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(campaign_id, 1);
+
+    // One above the cap must fail.
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        CAMPAIGN_FUNDING_GOAL_MAX + 1,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooHigh);
+
+    // Admin raises the cap.
+    let new_max = CAMPAIGN_FUNDING_GOAL_MAX * 2;
+    client.set_max_campaign_funding_goal(&admin, &new_max);
+    assert_eq!(client.get_max_campaign_funding_goal(), new_max);
+
+    // Previously-rejected goal now succeeds.
+    let campaign_id2 = client.create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        CAMPAIGN_FUNDING_GOAL_MAX + 1,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(campaign_id2, 2);
+}
+
+#[test]
 fn test_contribute_and_withdraw_success() {
     let (env, admin, creator, contributor1, _, token, token_admin, client) = setup_env();
 


### PR DESCRIPTION
Title: feat: max funding goal cap (#195) + create_campaign fuzz tests (#142)

Body:
## Summary

Closes #195 — Add admin-configurable max funding goal cap (anti-spam)
Closes #142 — Fuzz tests for create_campaign validation inputs

## Changes

### #195 — Max funding goal cap
- Added `CAMPAIGN_FUNDING_GOAL_MAX = 10^15` constant
- Added `DataKey::MaxCampaignFundingGoal` with `get/set_max_campaign_funding_goal` storage helpers
- Added `Error::FundingGoalTooHigh` (code 36)
- `create_campaign` now rejects `funding_goal > max_cap`
- Exposed `get_max_campaign_funding_goal` and `set_max_campaign_funding_goal` admin functions (same pattern as the existing min-goal functions)

### #142 — Fuzz tests for create_campaign
- New `src/create_campaign_proptest.rs` with proptest covering all validation paths:
  - funding_goal: valid range, non-positive, below min, above max
  - duration_days: valid range, above max, zero
  - revenue_share_percentage: valid, above max, enabled-with-zero
  - max_contribution_per_user: non-negative passes, negative fails
  - admin-raised cap allows previously-rejected goals

### Integration test (test.rs)
- `test_max_campaign_funding_goal_boundary_and_admin_update`: exact-max passes, one-above fails, admin raises cap, previously-rejected goal succeeds

## Test results
163 tests — all pass.
