### PR TITLE
feat: add per-campaign fee override, category duration caps, deadline…

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,4 +75,8 @@ pub enum Error {
     AdminVerificationConflict = 34,
     /// Community verification was attempted on an already verified campaign.
     CommunityVerificationConflict = 35,
+    /// The campaign deadline has already been extended once.
+    DeadlineAlreadyExtended = 36,
+    /// Extension would push the deadline past the allowed maximum.
+    ExtensionTooLong = 37,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,9 @@ impl ProofOfHeart {
         if funding_goal < get_min_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MIN) {
             return Err(Error::FundingGoalTooLow);
         }
-        if !(CAMPAIGN_DURATION_MIN_DAYS..=CAMPAIGN_DURATION_MAX_DAYS).contains(&duration_days) {
+        let duration_max = get_category_duration_cap(&env, category)
+            .unwrap_or(CAMPAIGN_DURATION_MAX_DAYS);
+        if !(CAMPAIGN_DURATION_MIN_DAYS..=duration_max).contains(&duration_days) {
             return Err(Error::InvalidDuration);
         }
         if title.len() < CAMPAIGN_TITLE_MIN_LEN || title.len() > CAMPAIGN_TITLE_MAX_LEN {
@@ -283,6 +285,8 @@ impl ProofOfHeart {
             has_revenue_sharing,
             revenue_share_percentage,
             max_contribution_per_user,
+            fee_override: None,
+            deadline_extended: false,
         };
 
         set_campaign(&env, count, &campaign);
@@ -446,7 +450,9 @@ impl ProofOfHeart {
         }
 
         bump_instance_ttl(&env);
-        let platform_fee = get_platform_fee(&env);
+        let platform_fee = campaign
+            .fee_override
+            .unwrap_or_else(|| get_platform_fee(&env));
         let fee_amount = (campaign.amount_raised * (platform_fee as i128)) / 10000;
         let total_after_fee = campaign.amount_raised - fee_amount;
 
@@ -1150,6 +1156,99 @@ impl ProofOfHeart {
         Ok(())
     }
 
+    /// Sets a per-campaign platform fee override (admin only).
+    ///
+    /// Pass `fee_bps = 0` for a 0% fee. Falls back to the global fee when no
+    /// override is set. The override is stored on the Campaign struct so it
+    /// survives even if the global fee changes later.
+    ///
+    /// # Authorization
+    /// Requires `admin.require_auth()`.
+    pub fn set_campaign_fee_override(
+        env: Env,
+        admin: Address,
+        campaign_id: u32,
+        fee_bps: u32,
+    ) -> Result<(), Error> {
+        assert_admin(&env, &admin)?;
+        let mut campaign = get_campaign_or_error(&env, campaign_id)?;
+        if fee_bps > PLATFORM_FEE_MAX_BPS {
+            return Err(Error::ValidationFailed);
+        }
+        bump_instance_ttl(&env);
+        campaign.fee_override = Some(fee_bps);
+        set_campaign(&env, campaign_id, &campaign);
+        env.events()
+            .publish(("campaign_fee_override_set", campaign_id), fee_bps);
+        Ok(())
+    }
+
+    /// Sets the maximum campaign duration (in days) for a category (admin only).
+    ///
+    /// Campaigns in this category will be rejected if `duration_days` exceeds
+    /// `max_days`. Omit (by not calling this) to keep the default 365-day cap.
+    ///
+    /// # Authorization
+    /// Requires `admin.require_auth()`.
+    pub fn set_category_duration_cap(
+        env: Env,
+        admin: Address,
+        category: Category,
+        max_days: u64,
+    ) -> Result<(), Error> {
+        assert_admin(&env, &admin)?;
+        if max_days < CAMPAIGN_DURATION_MIN_DAYS || max_days > CAMPAIGN_DURATION_MAX_DAYS {
+            return Err(Error::ValidationFailed);
+        }
+        bump_instance_ttl(&env);
+        storage::set_category_duration_cap(&env, category, max_days);
+        env.events()
+            .publish(("category_duration_cap_set", category as u32), max_days);
+        Ok(())
+    }
+
+    /// Extends the deadline of a campaign by `additional_days` (creator only).
+    ///
+    /// Rules: max one extension per campaign, max 30 extra days, only before
+    /// the original deadline.
+    ///
+    /// # Authorization
+    /// Requires `campaign.creator.require_auth()`.
+    pub fn extend_campaign_deadline(
+        env: Env,
+        campaign_id: u32,
+        additional_days: u64,
+    ) -> Result<(), Error> {
+        let mut campaign = get_creator_campaign(&env, campaign_id)?;
+        Self::require_not_paused(&env)?;
+
+        if campaign.deadline_extended {
+            return Err(Error::DeadlineAlreadyExtended);
+        }
+        if env.ledger().timestamp() >= campaign.deadline {
+            return Err(Error::DeadlinePassed);
+        }
+        if additional_days == 0 || additional_days > 30 {
+            return Err(Error::ExtensionTooLong);
+        }
+
+        let new_deadline = campaign
+            .deadline
+            .checked_add(additional_days * 86400)
+            .ok_or(Error::Overflow)?;
+
+        bump_instance_ttl(&env);
+        campaign.deadline = new_deadline;
+        campaign.deadline_extended = true;
+        set_campaign(&env, campaign_id, &campaign);
+
+        env.events().publish(
+            ("campaign_deadline_extended", campaign_id),
+            additional_days,
+        );
+        Ok(())
+    }
+
     /// Sets a personal contribution cap for a specific campaign.
     ///
     /// # Arguments
@@ -1621,6 +1720,8 @@ impl ProofOfHeart {
     }
 }
 
+#[cfg(test)]
+mod tests;
 #[cfg(test)]
 mod admin_transfer_test;
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -81,6 +81,8 @@ pub enum DataKey {
     CreationDisabled,
     /// Contributor count for a campaign.
     ContributorCount(u32),
+    /// Per-category maximum duration cap in days, keyed by category discriminant.
+    CategoryDurationCap(u32),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -620,4 +622,16 @@ pub fn set_creation_disabled(env: &Env, disabled: bool) {
     env.storage()
         .instance()
         .set(&DataKey::CreationDisabled, &disabled);
+}
+
+// ── Per-category duration cap ─────────────────────────────────────────────────
+
+pub fn get_category_duration_cap(env: &Env, category: Category) -> Option<u64> {
+    let key = DataKey::CategoryDurationCap(category as u32);
+    env.storage().instance().get(&key)
+}
+
+pub fn set_category_duration_cap(env: &Env, category: Category, max_days: u64) {
+    let key = DataKey::CategoryDurationCap(category as u32);
+    env.storage().instance().set(&key, &max_days);
 }

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -1,0 +1,89 @@
+pub use crate::storage::set_min_campaign_funding_goal;
+pub use crate::{Category, CreateCampaignParams, ProofOfHeart, ProofOfHeartClient};
+pub use soroban_sdk::token::Client as TokenClient;
+pub use soroban_sdk::token::StellarAssetClient as TokenAdminClient;
+pub use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, IntoVal, String, Symbol,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn make_params(
+    creator: Address,
+    title: String,
+    description: String,
+    funding_goal: i128,
+    duration_days: u64,
+    category: Category,
+    has_revenue_sharing: bool,
+    revenue_share_percentage: u32,
+    max_contribution_per_user: i128,
+) -> CreateCampaignParams {
+    CreateCampaignParams {
+        creator,
+        title,
+        description,
+        funding_goal,
+        duration_days,
+        category,
+        has_revenue_sharing,
+        revenue_share_percentage,
+        max_contribution_per_user,
+    }
+}
+
+pub(crate) fn setup_env_with_default_min<'a>() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    TokenClient<'a>,
+    TokenAdminClient<'a>,
+    ProofOfHeartClient<'a>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let contributor1 = Address::generate(&env);
+    let contributor2 = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token = TokenClient::new(&env, &token_address);
+    let token_admin = TokenAdminClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    client.init(&admin, &token_address, &300);
+
+    (
+        env,
+        admin,
+        creator,
+        contributor1,
+        contributor2,
+        token,
+        token_admin,
+        client,
+    )
+}
+
+pub(crate) fn setup_env<'a>() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    TokenClient<'a>,
+    TokenAdminClient<'a>,
+    ProofOfHeartClient<'a>,
+) {
+    let setup = setup_env_with_default_min();
+    setup.0.as_contract(&setup.7.address, || {
+        set_min_campaign_funding_goal(&setup.0, 1)
+    });
+    setup
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,19 @@
+pub(crate) mod helpers;
+
+mod test_admin;
+mod test_campaign_create;
+mod test_campaign_update;
+mod test_contribute;
+mod test_contribute_caps;
+mod test_deadline_ext;
+mod test_duration_cap;
+mod test_fee_override;
+mod test_init;
+mod test_listing;
+mod test_refund;
+mod test_refund_edge;
+mod test_revenue;
+mod test_revenue_deposit;
+mod test_voting;
+mod test_voting_verify;
+mod test_withdraw;

--- a/src/tests/test_admin.rs
+++ b/src/tests/test_admin.rs
@@ -1,0 +1,103 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{String};
+
+#[test]
+fn test_update_platform_fee() {
+    let (env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    let result = client.try_update_platform_fee(&500);
+    assert!(result.is_ok());
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let expected_topics = (String::from_str(&env, "fee_updated"),).into_val(&env);
+    assert_eq!(last_event.1, expected_topics);
+
+    let data_vec: soroban_sdk::Vec<u32> = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(data_vec.get(0).unwrap(), 300);
+    assert_eq!(data_vec.get(1).unwrap(), 500);
+
+    let result = client.try_update_platform_fee(&5000);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_pause_and_unpause() {
+    let (_env, _admin, _creator, _contributor1, _, _token, _token_admin, client) = setup_env();
+
+    assert!(!client.is_paused());
+
+    client.pause();
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_pause_blocks_state_changing_operations() {
+    let (env, _admin, creator, contributor1, _contributor2, token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &2000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Paused Test"),
+        String::from_str(&env, "Testing pause functionality"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.pause();
+    assert!(client.is_paused());
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "New Campaign"),
+        String::from_str(&env, "Testing pause functionality"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let res = client.try_contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let res = client.try_cancel_campaign(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let res = client.try_verify_campaign(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let res = client.try_update_platform_fee(&400);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.title, String::from_str(&env, "Paused Test"));
+
+    assert!(client.is_paused());
+
+    client.unpause();
+    assert!(!client.is_paused());
+
+    client.contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 500);
+
+    let _ = token;
+}

--- a/src/tests/test_campaign_create.rs
+++ b/src/tests/test_campaign_create.rs
@@ -1,0 +1,204 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+#[test]
+fn test_create_and_validation() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let title = String::from_str(&env, "Science Book");
+    let desc = String::from_str(&env, "Teaching science to kids");
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), desc.clone(), 0, 30, Category::Publisher, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalMustBePositive);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), desc.clone(), 500, 0, Category::Publisher, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), desc.clone(), 500, 400, Category::Publisher, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), desc.clone(), 500, 30, Category::Educator, true, 1000, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::RevenueShareOnlyForStartup);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), title.clone(), desc.clone(), 2000, 30,
+        Category::EducationalStartup, true, 1500, 0i128,
+    ));
+    assert_eq!(campaign_id, 1);
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.id, 1);
+    assert_eq!(campaign.funding_goal, 2000);
+    assert!(campaign.is_active);
+    assert!(!campaign.is_verified);
+}
+
+#[test]
+fn test_get_campaign_not_found() {
+    let (_env, _admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+    let res = client.try_get_campaign(&999);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_get_version() {
+    let (_env, _admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+    assert_eq!(client.get_version(), 1u32);
+}
+
+#[test]
+fn test_admin_verify_campaign_success() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Admin Verification"),
+        String::from_str(&env, "Admin verifies campaign"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    assert!(client.get_campaign(&campaign_id).is_verified);
+}
+
+#[test]
+fn test_admin_verify_campaign_duplicate_attempt() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Duplicate Verification"),
+        String::from_str(&env, "Cannot verify twice"), 1000, 30,
+        Category::Publisher, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    let res = client.try_verify_campaign(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AdminVerificationConflict);
+}
+
+#[test]
+fn test_description_length_boundaries() {
+    extern crate std;
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let title = String::from_str(&env, "Title");
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), String::from_str(&env, ""), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    assert!(client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), String::from_str(&env, "a"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    )).is_ok());
+
+    let desc_1000 = "a".repeat(1000);
+    assert!(client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), String::from_str(&env, &desc_1000), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    )).is_ok());
+
+    let desc_1001 = "a".repeat(1001);
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), title.clone(), String::from_str(&env, &desc_1001), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_title_length_boundaries() {
+    extern crate std;
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let desc = String::from_str(&env, "Description");
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, ""), desc.clone(), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    assert!(client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "a"), desc.clone(), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    )).is_ok());
+
+    let title_100 = "a".repeat(100);
+    assert!(client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, &title_100), desc.clone(), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    )).is_ok());
+
+    let title_101 = "a".repeat(101);
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, &title_101), desc.clone(), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_revenue_share_percentage_normalised_to_zero_when_disabled() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "No Revenue"),
+        String::from_str(&env, "Desc"), 1000, 30, Category::Educator, false, 12345, 0i128,
+    ));
+    let campaign = client.get_campaign(&id);
+    assert_eq!(campaign.revenue_share_percentage, 0);
+    assert!(!campaign.has_revenue_sharing);
+}
+
+#[test]
+fn test_revenue_share_above_max_rejected_even_without_flag() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Bad Revenue"),
+        String::from_str(&env, "Desc"), 1000, 30, Category::Educator, false, 9999, 0i128,
+    ));
+    assert_eq!(client.get_campaign(&id).revenue_share_percentage, 0);
+}
+
+#[test]
+fn test_revenue_share_with_flag_true_above_max_rejected() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Too High"),
+        String::from_str(&env, "Desc"), 1000, 30,
+        Category::EducationalStartup, true, 5001, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidRevenueShare);
+}
+
+#[test]
+fn test_campaign_count_cannot_reset_after_deployment() {
+    let (env, _admin, creator, _, _, token, _, client) = setup_env();
+
+    assert_eq!(client.get_campaign_count(), 0);
+    for i in 1u32..=3 {
+        let id = client.create_campaign(&make_params(
+            creator.clone(), String::from_str(&env, "Campaign"),
+            String::from_str(&env, "Desc"), 1000, 30, Category::Educator, false, 0, 0i128,
+        ));
+        assert_eq!(id, i);
+    }
+    assert_eq!(client.get_campaign_count(), 3);
+
+    client.update_platform_fee(&500);
+    assert_eq!(client.get_campaign_count(), 3);
+
+    let new_admin = Address::generate(&env);
+    client.update_admin(&new_admin);
+    client.accept_admin_transfer();
+    assert_eq!(client.get_campaign_count(), 3);
+
+    let res = client.try_init(&new_admin, &token.address, &300);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyInitialized);
+    assert_eq!(client.get_campaign_count(), 3);
+}

--- a/src/tests/test_campaign_update.rs
+++ b/src/tests/test_campaign_update.rs
@@ -1,0 +1,239 @@
+use super::helpers::*;
+use crate::{Category, Error, MaybePendingCreator};
+use soroban_sdk::{
+    testutils::{AuthorizedFunction, AuthorizedInvocation},
+    Address, IntoVal, String, Symbol,
+};
+
+#[test]
+fn test_update_campaign_allows_verified_campaign_before_contributions() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Original Title"),
+        String::from_str(&env, "Original Description"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    let new_title = String::from_str(&env, "New Title");
+    let new_desc = String::from_str(&env, "New Description");
+    let res = client.try_update_campaign(&campaign_id, &new_title, &new_desc);
+    assert!(res.is_ok());
+
+    let updated = client.get_campaign(&campaign_id);
+    assert_eq!(updated.title, new_title);
+    assert_eq!(updated.description, new_desc);
+}
+
+#[test]
+fn test_update_campaign_allows_verified_campaign_with_votes_before_contributions() {
+    let (env, _admin, creator, contributor1, contributor2, _, token_admin, client) = setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Original Title"),
+        String::from_str(&env, "Original Description"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &true);
+    client.verify_campaign_with_votes(&campaign_id);
+    assert!(client.get_campaign(&campaign_id).is_verified);
+
+    let new_title = String::from_str(&env, "New Title");
+    let new_desc = String::from_str(&env, "New Description");
+    assert!(client.try_update_campaign(&campaign_id, &new_title, &new_desc).is_ok());
+
+    let updated = client.get_campaign(&campaign_id);
+    assert_eq!(updated.title, new_title);
+    assert_eq!(updated.description, new_desc);
+}
+
+#[test]
+fn test_update_campaign_description_success() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Original Title"),
+        String::from_str(&env, "Original description"), 1_000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let new_desc = String::from_str(&env, "Updated description with more detail");
+    assert!(client.try_update_campaign_description(&campaign_id, &new_desc).is_ok());
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.description, new_desc);
+    assert_eq!(campaign.funding_goal, 1_000);
+}
+
+#[test]
+fn test_update_campaign_description_rejects_cancelled() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Title"),
+        String::from_str(&env, "Desc"), 1_000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+    client.cancel_campaign(&campaign_id);
+
+    let res = client.try_update_campaign_description(&campaign_id, &String::from_str(&env, "New desc"));
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_update_campaign_description_rejects_empty() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Title"),
+        String::from_str(&env, "Desc"), 1_000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let res = client.try_update_campaign_description(&campaign_id, &String::from_str(&env, ""));
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_update_campaign_description_not_found() {
+    let (env, _, _, _, _, _, _, client) = setup_env();
+    let res = client.try_update_campaign_description(&999, &String::from_str(&env, "Some desc"));
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_campaign_ownership_transfer_flow() {
+    let (env, _admin, creator, contributor1, contributor2, _, _, client) = setup_env();
+    let new_creator = contributor1;
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Transfer Test"),
+        String::from_str(&env, "Desc"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.initiate_campaign_transfer(&campaign_id, &new_creator);
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.pending_creator, MaybePendingCreator::Some(new_creator.clone()));
+    assert_eq!(campaign.creator, creator);
+
+    client.accept_campaign_transfer(&campaign_id);
+    let campaign_after = client.get_campaign(&campaign_id);
+    assert_eq!(campaign_after.creator, new_creator.clone());
+    assert_eq!(campaign_after.pending_creator, MaybePendingCreator::None);
+
+    let updated_description = String::from_str(&env, "Managed by the transferred owner");
+    client.update_campaign_description(&campaign_id, &updated_description);
+
+    let auths = env.auths();
+    let (auth_addr, invocation) = auths.last().unwrap();
+    assert_eq!(auth_addr, &new_creator);
+    assert_eq!(
+        invocation,
+        &AuthorizedInvocation {
+            function: AuthorizedFunction::Contract((
+                client.address.clone(),
+                Symbol::new(&env, "update_campaign_description"),
+                (campaign_id, updated_description).into_val(&env),
+            )),
+            sub_invocations: Default::default(),
+        }
+    );
+
+    let campaign_id_2 = client.create_campaign(&make_params(
+        new_creator.clone(), String::from_str(&env, "Cancel Test"),
+        String::from_str(&env, "Desc"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id_2);
+    client.initiate_campaign_transfer(&campaign_id_2, &contributor2);
+    client.cancel_campaign_transfer(&campaign_id_2);
+    let final_campaign = client.get_campaign(&campaign_id_2);
+    assert_eq!(final_campaign.pending_creator, MaybePendingCreator::None);
+}
+
+#[test]
+fn test_campaign_transfer_validations() {
+    let (env, _admin, creator, contributor1, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Transfer Guardrails"),
+        String::from_str(&env, "Desc"), 1000, 30,
+        Category::Publisher, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let res = client.try_initiate_campaign_transfer(&campaign_id, &creator);
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidNewOwner);
+
+    let res = client.try_accept_campaign_transfer(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoTransferPending);
+
+    client.initiate_campaign_transfer(&campaign_id, &contributor1);
+    client.cancel_campaign_transfer(&campaign_id);
+
+    let auths = env.auths();
+    let (auth_addr, _) = auths.last().unwrap();
+    assert_eq!(auth_addr, &creator);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.pending_creator, MaybePendingCreator::None);
+
+    let res = client.try_cancel_campaign_transfer(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoTransferPending);
+}
+
+#[test]
+fn test_cancel_campaign_already_cancelled_is_terminal() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Terminal Test"),
+        String::from_str(&env, "Already cancelled"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.cancel_campaign(&campaign_id);
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(campaign.is_cancelled);
+    assert!(!campaign.is_active);
+
+    let res = client.try_cancel_campaign(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_cancel_campaign_after_withdrawal_is_terminal() {
+    let (env, _admin, creator, contributor1, _, _, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Withdrawal Terminal"),
+        String::from_str(&env, "Funds already out"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(campaign.funds_withdrawn);
+    assert!(!campaign.is_active);
+
+    let res = client.try_cancel_campaign(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}

--- a/src/tests/test_contribute.rs
+++ b/src/tests/test_contribute.rs
@@ -1,0 +1,294 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_contribute_and_withdraw_success() {
+    let (env, admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Code Camp"),
+        String::from_str(&env, "Learn Rust"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+
+    assert_eq!(token.balance(&contributor1), 4000);
+    assert_eq!(token.balance(&client.address), 1000);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 1000);
+
+    client.withdraw_funds(&campaign_id);
+
+    assert_eq!(token.balance(&admin), 30);
+    assert_eq!(token.balance(&creator), 970);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(!campaign.is_active);
+    assert!(campaign.funds_withdrawn);
+}
+
+#[test]
+fn test_creator_cannot_contribute_to_own_campaign() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Self Funding Block"),
+        String::from_str(&env, "Creator should not contribute"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let res = client.try_contribute(&campaign_id, &creator, &100);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}
+
+#[test]
+fn test_failure_states() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let duration_days = 2;
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Deadline Test"),
+        String::from_str(&env, "Desc"), 1000, duration_days,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let res = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    let res = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalNotReached);
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: env.ledger().timestamp() + (duration_days * 86450),
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
+
+    let res = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalNotReached);
+
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 5000);
+}
+
+#[test]
+fn test_multiple_concurrent_campaigns_are_isolated() {
+    let (env, _admin, creator1, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    let creator2 = Address::generate(&env);
+    let creator3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &10000);
+    token_admin.mint(&contributor2, &10000);
+    token_admin.mint(&creator3, &10000);
+
+    let campaign_1 = client.create_campaign(&make_params(
+        creator1.clone(), String::from_str(&env, "Campaign 1"),
+        String::from_str(&env, "Educator campaign"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_1);
+
+    let campaign_2 = client.create_campaign(&make_params(
+        creator2.clone(), String::from_str(&env, "Campaign 2"),
+        String::from_str(&env, "Learner campaign"), 1500, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_2);
+
+    let campaign_3 = client.create_campaign(&make_params(
+        creator3.clone(), String::from_str(&env, "Campaign 3"),
+        String::from_str(&env, "Startup campaign"), 2000, 30,
+        Category::EducationalStartup, true, 1500, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_3);
+
+    assert_eq!(campaign_1, 1);
+    assert_eq!(campaign_2, 2);
+    assert_eq!(campaign_3, 3);
+    assert_eq!(client.get_campaign_count(), 3);
+
+    client.contribute(&campaign_1, &contributor1, &1000);
+    client.contribute(&campaign_2, &contributor1, &400);
+    client.contribute(&campaign_2, &contributor2, &500);
+    client.contribute(&campaign_3, &contributor1, &1200);
+    client.contribute(&campaign_3, &contributor2, &800);
+
+    assert_eq!(client.get_contribution(&campaign_1, &contributor1), 1000);
+    assert_eq!(client.get_contribution(&campaign_1, &contributor2), 0);
+    assert_eq!(client.get_contribution(&campaign_2, &contributor1), 400);
+    assert_eq!(client.get_contribution(&campaign_2, &contributor2), 500);
+    assert_eq!(client.get_contribution(&campaign_3, &contributor1), 1200);
+    assert_eq!(client.get_contribution(&campaign_3, &contributor2), 800);
+
+    client.withdraw_funds(&campaign_1);
+
+    assert!(client.get_campaign(&campaign_1).funds_withdrawn);
+    assert!(!client.get_campaign(&campaign_1).is_active);
+    assert_eq!(client.get_campaign(&campaign_2).amount_raised, 900);
+    assert!(!client.get_campaign(&campaign_2).funds_withdrawn);
+    assert_eq!(client.get_campaign(&campaign_3).amount_raised, 2000);
+
+    client.cancel_campaign(&campaign_2);
+    assert!(client.get_campaign(&campaign_2).is_cancelled);
+    assert!(client.get_campaign(&campaign_3).is_active);
+
+    client.deposit_revenue(&campaign_3, &3000);
+
+    assert_eq!(client.get_revenue_pool(&campaign_1), 0);
+    assert_eq!(client.get_revenue_pool(&campaign_2), 0);
+    assert_eq!(client.get_revenue_pool(&campaign_3), 3000);
+
+    assert_eq!(token.balance(&client.address), 5900);
+    assert_eq!(token.balance(&creator3), 7000);
+}
+
+#[test]
+fn test_deadline_boundary() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Boundary Test"),
+        String::from_str(&env, "Testing exact deadline boundary"), 1000, 2,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    client.contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 500);
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
+}
+
+#[test]
+fn test_contribution_accounting_invariant() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    let contributor3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &3000);
+    token_admin.mint(&contributor2, &3000);
+    token_admin.mint(&contributor3, &3000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Invariant Campaign"),
+        String::from_str(&env, "Accounting invariant check"), 5000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &500);
+    client.contribute(&campaign_id, &contributor2, &750);
+    client.contribute(&campaign_id, &contributor3, &250);
+    client.contribute(&campaign_id, &contributor1, &300);
+    client.contribute(&campaign_id, &contributor2, &200);
+
+    let c1 = client.get_contribution(&campaign_id, &contributor1);
+    let c2 = client.get_contribution(&campaign_id, &contributor2);
+    let c3 = client.get_contribution(&campaign_id, &contributor3);
+
+    assert_eq!(c1, 800);
+    assert_eq!(c2, 950);
+    assert_eq!(c3, 250);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(c1 + c2 + c3, campaign.amount_raised);
+}
+
+#[test]
+fn test_view_functions_error_handling() {
+    let (env, _admin, creator, contributor1, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "View Test"),
+        String::from_str(&env, "Testing view functions"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let stranger = Address::generate(&env);
+    let invalid_id = 999u32;
+
+    let res = client.try_get_campaign(&invalid_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+
+    assert_eq!(client.get_contribution(&campaign_id, &stranger), 0);
+    assert_eq!(client.get_contribution(&invalid_id, &contributor1), 0);
+    assert_eq!(client.get_revenue_pool(&invalid_id), 0);
+    assert_eq!(client.get_revenue_claimed(&campaign_id, &stranger), 0);
+    assert_eq!(client.get_revenue_claimed(&invalid_id, &contributor1), 0);
+}
+
+#[test]
+fn test_contribute_one_second_before_deadline() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Almost Deadline"),
+        String::from_str(&env, "Desc"), 1000, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline - 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    client.contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 500);
+}

--- a/src/tests/test_contribute_caps.rs
+++ b/src/tests/test_contribute_caps.rs
@@ -1,0 +1,110 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_contribution_cap_persists_across_refund_recontribution_cycles() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5_000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Cap persistence"),
+        String::from_str(&env, "lifetime cap test"), 2_000, 1,
+        Category::Learner, false, 0, 1_000i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &900);
+    client.cancel_campaign(&campaign_id);
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+    assert_eq!(client.get_lifetime_contribution(&campaign_id, &contributor1), 900);
+}
+
+#[test]
+fn test_personal_cap_enforcement() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Cap Test"),
+        String::from_str(&env, "Testing caps"), 5000, 30,
+        Category::Educator, false, 0, 1000i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    client.set_personal_cap(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_personal_cap(&campaign_id, &contributor1), 500);
+
+    client.contribute(&campaign_id, &contributor1, &400);
+    let res = client.try_contribute(&campaign_id, &contributor1, &200);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContributionCapExceeded);
+
+    client.set_personal_cap(&campaign_id, &contributor1, &2000);
+    client.contribute(&campaign_id, &contributor1, &500);
+    let res = client.try_contribute(&campaign_id, &contributor1, &200);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContributionCapExceeded);
+}
+
+#[test]
+fn test_anomaly_auto_pause_huge_contribution() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Science Book"),
+        String::from_str(&env, "Teaching science to kids"), 2000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    let res = client.try_contribute(&campaign_id, &contributor1, &4001);
+    assert!(res.is_ok());
+    assert!(client.is_paused());
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+
+    client.unpause();
+    assert!(!client.is_paused());
+
+    client.contribute(&campaign_id, &contributor1, &100);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 100);
+}
+
+#[test]
+fn test_anomaly_auto_pause_burst() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Burst Test"),
+        String::from_str(&env, "Testing burst"), 2000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    for _ in 0..10 {
+        client.contribute(&campaign_id, &contributor1, &10);
+    }
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 100);
+
+    let res = client.try_contribute(&campaign_id, &contributor1, &10);
+    assert!(res.is_ok());
+    assert!(client.is_paused());
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 100);
+
+    client.unpause();
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: env.ledger().timestamp(),
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence() + 1,
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    client.contribute(&campaign_id, &contributor1, &10);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 110);
+}

--- a/src/tests/test_deadline_ext.rs
+++ b/src/tests/test_deadline_ext.rs
@@ -1,0 +1,114 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_extend_campaign_deadline_happy_path() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Extend Me"),
+        String::from_str(&env, "Will be extended"), 1000, 10,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    let original_deadline = client.get_campaign(&id).deadline;
+    client.extend_campaign_deadline(&id, &7);
+
+    let new_deadline = client.get_campaign(&id).deadline;
+    assert_eq!(new_deadline, original_deadline + 7 * 86400);
+    assert!(client.get_campaign(&id).deadline_extended);
+}
+
+#[test]
+fn test_extend_deadline_emits_event() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Event Extension"),
+        String::from_str(&env, "Check event"), 1000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.extend_campaign_deadline(&id, &5);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(last_event.1.len(), 2);
+}
+
+#[test]
+fn test_extend_deadline_double_extension_rejected() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Double Extension"),
+        String::from_str(&env, "Only one extension"), 1000, 10,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    client.extend_campaign_deadline(&id, &7);
+
+    let res = client.try_extend_campaign_deadline(&id, &7);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlineAlreadyExtended);
+}
+
+#[test]
+fn test_extend_deadline_post_deadline_rejected() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Expired"),
+        String::from_str(&env, "Past deadline"), 1000, 1,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    let deadline = client.get_campaign(&id).deadline;
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_extend_campaign_deadline(&id, &7);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
+}
+
+#[test]
+fn test_extend_deadline_too_many_days_rejected() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Too Long"),
+        String::from_str(&env, "Extension too long"), 1000, 10,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    let res = client.try_extend_campaign_deadline(&id, &31);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ExtensionTooLong);
+
+    let res = client.try_extend_campaign_deadline(&id, &0);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ExtensionTooLong);
+}
+
+#[test]
+fn test_extend_deadline_max_30_days_allowed() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Max Extension"),
+        String::from_str(&env, "Exactly 30 days"), 1000, 10,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    let original_deadline = client.get_campaign(&id).deadline;
+    client.extend_campaign_deadline(&id, &30);
+
+    let new_deadline = client.get_campaign(&id).deadline;
+    assert_eq!(new_deadline, original_deadline + 30 * 86400);
+}

--- a/src/tests/test_duration_cap.rs
+++ b/src/tests/test_duration_cap.rs
@@ -1,0 +1,74 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_category_duration_cap_enforced() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_duration_cap(&admin, &Category::EducationalStartup, &60);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Startup"),
+        String::from_str(&env, "Startup desc"), 1000, 61,
+        Category::EducationalStartup, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Startup OK"),
+        String::from_str(&env, "Startup desc"), 1000, 60,
+        Category::EducationalStartup, false, 0, 0i128,
+    ));
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_category_duration_cap_other_categories_unaffected() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_duration_cap(&admin, &Category::Learner, &10);
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Educator"),
+        String::from_str(&env, "Full duration"), 1000, 365,
+        Category::Educator, false, 0, 0i128,
+    ));
+    assert_eq!(id, 1);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Learner"),
+        String::from_str(&env, "Too long"), 1000, 11,
+        Category::Learner, false, 0, 0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
+}
+
+#[test]
+fn test_category_duration_cap_default_unchanged() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Default"),
+        String::from_str(&env, "Default cap"), 1000, 365,
+        Category::Publisher, false, 0, 0i128,
+    ));
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_category_duration_cap_above_365_rejected() {
+    let (_env, admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let res = client.try_set_category_duration_cap(&admin, &Category::Learner, &366);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_category_duration_cap_non_admin_rejected() {
+    let (env, _admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let impostor = Address::generate(&env);
+    let res = client.try_set_category_duration_cap(&impostor, &Category::Learner, &30);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}

--- a/src/tests/test_fee_override.rs
+++ b/src/tests/test_fee_override.rs
@@ -1,0 +1,86 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_campaign_fee_override_zero_percent() {
+    let (env, admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Charity"),
+        String::from_str(&env, "0% fee campaign"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.set_campaign_fee_override(&admin, &campaign_id, &0);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    assert_eq!(token.balance(&admin), 0);
+    assert_eq!(token.balance(&creator), 1000);
+}
+
+#[test]
+fn test_campaign_fee_override_custom_percent() {
+    let (env, admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Reduced Fee"),
+        String::from_str(&env, "1% fee"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.set_campaign_fee_override(&admin, &campaign_id, &100);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    assert_eq!(token.balance(&admin), 10);
+    assert_eq!(token.balance(&creator), 990);
+}
+
+#[test]
+fn test_campaign_fee_override_default_unchanged() {
+    let (env, admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Default Fee"),
+        String::from_str(&env, "Global fee applies"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    assert_eq!(token.balance(&admin), 30);
+    assert_eq!(token.balance(&creator), 970);
+}
+
+#[test]
+fn test_campaign_fee_override_above_max_rejected() {
+    let (env, admin2, creator2, _c1, _c2, _token2, _token_admin2, client2) = setup_env();
+    let id = client2.create_campaign(&make_params(
+        creator2.clone(), String::from_str(&env, "X"),
+        String::from_str(&env, "X"), 1, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let res = client2.try_set_campaign_fee_override(&admin2, &id, &1001);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_campaign_fee_override_non_admin_rejected() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "X"),
+        String::from_str(&env, "X"), 1, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    let impostor = Address::generate(&env);
+    let res = client.try_set_campaign_fee_override(&impostor, &id, &0);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}

--- a/src/tests/test_init.rs
+++ b/src/tests/test_init.rs
@@ -1,0 +1,226 @@
+use super::helpers::*;
+use crate::{storage::set_min_campaign_funding_goal, Category, Error, CAMPAIGN_FUNDING_GOAL_MIN};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_init_only_once() {
+    let (_env, admin, _creator, _c1, _c2, token, _token_admin, client) = setup_env();
+    let res = client.try_init(&admin, &token.address, &300);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyInitialized);
+}
+
+#[test]
+fn test_platform_fee_cap_enforcement() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let contributor = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token = soroban_sdk::token::Client::new(&env, &token_address);
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, crate::ProofOfHeart);
+    let client = crate::ProofOfHeartClient::new(&env, &contract_id);
+
+    client.init(&admin, &token_address, &5000);
+    env.as_contract(&client.address, || set_min_campaign_funding_goal(&env, 1));
+    assert_eq!(client.get_platform_fee(), 1000);
+
+    token_admin.mint(&contributor, &2000);
+
+    let title = String::from_str(&env, "Fee Cap Test");
+    let desc = String::from_str(&env, "Testing platform fee cap enforcement");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        title,
+        desc,
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor, &1000);
+
+    assert_eq!(token.balance(&contributor), 1000);
+    assert_eq!(token.balance(&client.address), 1000);
+
+    client.withdraw_funds(&campaign_id);
+
+    assert_eq!(token.balance(&admin), 100);
+    assert_eq!(token.balance(&creator), 900);
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+#[test]
+fn test_platform_fee_exact_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let contract_id = env.register_contract(None, crate::ProofOfHeart);
+    let client = crate::ProofOfHeartClient::new(&env, &contract_id);
+
+    client.init(&admin, &token_address, &1000);
+    assert_eq!(client.get_platform_fee(), 1000);
+}
+
+#[test]
+fn test_reinit_prevention() {
+    let (env, admin, _, _, _, token, _, client) = setup_env();
+
+    let attacker = Address::generate(&env);
+    let fake_token = Address::generate(&env);
+
+    let res = client.try_init(&attacker, &fake_token, &0);
+    assert!(res.is_err());
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token.address);
+    assert_eq!(client.get_platform_fee(), 300);
+}
+
+#[test]
+fn test_initialization_getters() {
+    let (_, admin, _, _, _, token, _, client) = setup_env();
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token.address);
+    assert_eq!(client.get_platform_fee(), 300);
+    assert_eq!(client.get_campaign_count(), 0);
+}
+
+#[test]
+fn test_init_returns_already_initialized_error() {
+    let (_env, admin, _creator, _c1, _c2, token, _token_admin, client) = setup_env();
+    let err = client
+        .try_init(&admin, &token.address, &300)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadyInitialized);
+}
+
+#[test]
+fn test_init_preserves_all_config_state() {
+    let (_env, admin, _creator, _c1, _c2, token, _token_admin, client) = setup_env();
+
+    let _ = client.try_init(&admin, &token.address, &999);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token.address);
+    assert_eq!(client.get_platform_fee(), 300);
+    assert_eq!(client.get_campaign_count(), 0);
+    assert_eq!(client.get_version(), 1);
+    assert_eq!(
+        client.get_min_votes_quorum(),
+        crate::voting::DEFAULT_MIN_VOTES_QUORUM
+    );
+    assert_eq!(
+        client.get_approval_threshold_bps(),
+        crate::voting::DEFAULT_APPROVAL_THRESHOLD_BPS
+    );
+}
+
+#[test]
+fn test_init_rejects_every_subsequent_call() {
+    let (_env, admin, _creator, _c1, _c2, token, _token_admin, client) = setup_env();
+
+    for _ in 0..3 {
+        let res = client.try_init(&admin, &token.address, &300);
+        assert_eq!(
+            res.unwrap_err().unwrap(),
+            Error::AlreadyInitialized,
+            "expected AlreadyInitialized on every repeated call"
+        );
+    }
+}
+
+#[test]
+fn test_init_cannot_overwrite_after_campaign_created() {
+    let (env, admin, creator, _c1, _c2, token, _token_admin, client) = setup_env();
+
+    let _ = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Test Campaign"),
+        String::from_str(&env, "Testing init idempotency after state change"),
+        1_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(client.get_campaign_count(), 1);
+
+    let res = client.try_init(&admin, &token.address, &0);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyInitialized);
+
+    assert_eq!(client.get_campaign_count(), 1);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token.address);
+    assert_eq!(client.get_platform_fee(), 300);
+}
+
+#[test]
+fn test_min_campaign_funding_goal_boundary_and_admin_update() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) =
+        setup_env_with_default_min();
+
+    assert_eq!(
+        client.get_min_campaign_funding_goal(),
+        CAMPAIGN_FUNDING_GOAL_MIN
+    );
+
+    let title = String::from_str(&env, "Minimum Goal");
+    let desc = String::from_str(&env, "Checks funding goal floor");
+
+    let below_min = CAMPAIGN_FUNDING_GOAL_MIN - 1;
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        below_min,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooLow);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        CAMPAIGN_FUNDING_GOAL_MIN,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(campaign_id, 1);
+
+    client.set_min_campaign_funding_goal(&admin, &500);
+    assert_eq!(client.get_min_campaign_funding_goal(), 500);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        title.clone(),
+        desc.clone(),
+        499,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooLow);
+}

--- a/src/tests/test_listing.rs
+++ b/src/tests/test_listing.rs
@@ -1,0 +1,267 @@
+use super::helpers::*;
+use crate::{Category};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_list_campaigns_exclusive_cursor_semantics() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    for i in 0..3 {
+        let id = client.create_campaign(&make_params(
+            creator.clone(),
+            String::from_str(&env, "Campaign"),
+            String::from_str(&env, "Desc"),
+            1000 + i as i128,
+            30,
+            Category::Learner,
+            false,
+            0,
+            0i128,
+        ));
+        assert_eq!(id, (i + 1) as u32);
+    }
+
+    let page1 = client.list_campaigns(&0, &2);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap().id, 1);
+    assert_eq!(page1.get(1).unwrap().id, 2);
+
+    let page2 = client.list_campaigns(&2, &2);
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2.get(0).unwrap().id, 3);
+}
+
+#[test]
+fn test_list_active_campaigns_exclusive_cursor_semantics() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    for _ in 0..4 {
+        let _ = client.create_campaign(&make_params(
+            creator.clone(),
+            String::from_str(&env, "Campaign"),
+            String::from_str(&env, "Desc"),
+            1000,
+            30,
+            Category::Learner,
+            false,
+            0,
+            0i128,
+        ));
+    }
+
+    client.cancel_campaign(&2);
+
+    let active1 = client.list_active_campaigns(&0, &2);
+    assert_eq!(active1.0.len(), 2);
+    assert_eq!(active1.0.get(0).unwrap().id, 1);
+    assert_eq!(active1.0.get(1).unwrap().id, 3);
+
+    let active2 = client.list_active_campaigns(&3, &2);
+    assert_eq!(active2.0.len(), 1);
+    assert_eq!(active2.0.get(0).unwrap().id, 4);
+}
+
+#[test]
+fn test_get_campaigns_by_category_with_pagination() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let id1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Learner 1"),
+        String::from_str(&env, "a"),
+        100,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let _id2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Publisher 1"),
+        String::from_str(&env, "b"),
+        100,
+        30,
+        Category::Publisher,
+        false,
+        0,
+        0i128,
+    ));
+    let id3 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Learner 2"),
+        String::from_str(&env, "c"),
+        100,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let learner_page_1 = client.get_campaigns_by_category(&Category::Learner, &0, &1);
+    assert_eq!(learner_page_1.len(), 1);
+    assert_eq!(learner_page_1.get(0).unwrap().id, id1);
+
+    let learner_page_2 = client.get_campaigns_by_category(&Category::Learner, &1, &1);
+    assert_eq!(learner_page_2.len(), 1);
+    assert_eq!(learner_page_2.get(0).unwrap().id, id3);
+
+    let publisher = client.get_campaigns_by_category(&Category::Publisher, &0, &10);
+    assert_eq!(publisher.len(), 1);
+    assert_eq!(publisher.get(0).unwrap().category, Category::Publisher);
+}
+
+#[test]
+fn test_get_platform_stats_returns_aggregates() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+    token_admin.mint(&contributor1, &2_000);
+    token_admin.mint(&contributor2, &2_000);
+
+    let c1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Stats 1"),
+        String::from_str(&env, "s1"),
+        500,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let c2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Stats 2"),
+        String::from_str(&env, "s2"),
+        500,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let _ = client.try_verify_campaign(&c1);
+    let _ = client.try_verify_campaign(&c2);
+    client.contribute(&c1, &contributor1, &400);
+    client.contribute(&c2, &contributor2, &300);
+    client.cancel_campaign(&c2);
+
+    let stats = client.get_platform_stats();
+    assert_eq!(stats.total_campaigns, 2);
+    assert_eq!(stats.active_campaigns, 1);
+    assert_eq!(stats.verified_campaigns, 2);
+    assert_eq!(stats.cancelled_campaigns, 1);
+    assert_eq!(stats.total_amount_raised, 700);
+}
+
+#[test]
+fn test_total_raised_global_tracking() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&contributor2, &5000);
+
+    let c1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 1"),
+        String::from_str(&env, "First"),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&c1);
+
+    let c2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 2"),
+        String::from_str(&env, "Second"),
+        2000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&c2);
+
+    assert_eq!(client.get_total_raised_global(), 0);
+
+    client.contribute(&c1, &contributor1, &500);
+    assert_eq!(client.get_total_raised_global(), 500);
+
+    client.contribute(&c2, &contributor2, &1000);
+    assert_eq!(client.get_total_raised_global(), 1500);
+
+    client.cancel_campaign(&c2);
+    client.claim_refund(&c2, &contributor2);
+    assert_eq!(client.get_total_raised_global(), 500);
+
+    client.contribute(&c1, &contributor2, &500);
+    assert_eq!(client.get_total_raised_global(), 1000);
+
+    client.withdraw_funds(&c1);
+    assert_eq!(client.get_total_raised_global(), 0);
+}
+
+#[test]
+fn test_creator_campaigns_listing_and_transfer() {
+    let (env, _admin, creator1, _c1, _c2, _token, _token_admin, client) = setup_env();
+    let creator2 = Address::generate(&env);
+
+    let id1 = client.create_campaign(&make_params(
+        creator1.clone(),
+        String::from_str(&env, "Campaign 1"),
+        String::from_str(&env, "First"),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    let id2 = client.create_campaign(&make_params(
+        creator1.clone(),
+        String::from_str(&env, "Campaign 2"),
+        String::from_str(&env, "Second"),
+        2000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let list1 = client.get_creator_campaigns(&creator1, &0, &10);
+    assert_eq!(list1.len(), 2);
+    assert_eq!(list1.get(0).unwrap().id, id1);
+    assert_eq!(list1.get(1).unwrap().id, id2);
+
+    let paginated1 = client.get_creator_campaigns(&creator1, &0, &1);
+    assert_eq!(paginated1.len(), 1);
+    assert_eq!(paginated1.get(0).unwrap().id, id1);
+
+    let paginated2 = client.get_creator_campaigns(&creator1, &1, &1);
+    assert_eq!(paginated2.len(), 1);
+    assert_eq!(paginated2.get(0).unwrap().id, id2);
+
+    let list2 = client.get_creator_campaigns(&creator2, &0, &10);
+    assert_eq!(list2.len(), 0);
+
+    client.initiate_campaign_transfer(&id1, &creator2);
+    client.accept_campaign_transfer(&id1);
+
+    let list1_after = client.get_creator_campaigns(&creator1, &0, &10);
+    assert_eq!(list1_after.len(), 1);
+    assert_eq!(list1_after.get(0).unwrap().id, id2);
+
+    let list2_after = client.get_creator_campaigns(&creator2, &0, &10);
+    assert_eq!(list2_after.len(), 1);
+    assert_eq!(list2_after.get(0).unwrap().id, id1);
+}

--- a/src/tests/test_refund.rs
+++ b/src/tests/test_refund.rs
@@ -1,0 +1,157 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{
+    testutils::{AuthorizedFunction, AuthorizedInvocation},
+    IntoVal, String, Symbol,
+};
+
+#[test]
+fn test_cancel_and_refund() {
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &2000);
+    token_admin.mint(&contributor2, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Failed Idea"),
+        String::from_str(&env, "Desc"), 5000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.contribute(&campaign_id, &contributor2, &500);
+
+    client.cancel_campaign(&campaign_id);
+    assert!(client.get_campaign(&campaign_id).is_cancelled);
+
+    client.claim_refund(&campaign_id, &contributor1);
+    client.claim_refund(&campaign_id, &contributor2);
+
+    assert_eq!(token.balance(&contributor1), 2000);
+    assert_eq!(token.balance(&contributor2), 1000);
+    assert_eq!(token.balance(&client.address), 0);
+}
+
+#[test]
+fn test_claim_refund_requires_contributor_auth() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Auth Refund"),
+        String::from_str(&env, "Only contributor can claim"), 5000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.cancel_campaign(&campaign_id);
+    client.claim_refund(&campaign_id, &contributor1);
+
+    let auths = env.auths();
+    assert_eq!(auths.len(), 1);
+    let (auth_addr, invocation) = &auths[0];
+    assert_eq!(auth_addr, &contributor1);
+    assert_eq!(
+        invocation,
+        &AuthorizedInvocation {
+            function: AuthorizedFunction::Contract((
+                client.address.clone(),
+                Symbol::new(&env, "claim_refund"),
+                (campaign_id, contributor1.clone()).into_val(&env),
+            )),
+            sub_invocations: Default::default(),
+        }
+    );
+
+    assert_eq!(token.balance(&contributor1), 2000);
+}
+
+#[test]
+fn test_double_refund_prevention() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Double Refund"),
+        String::from_str(&env, "Test double refund"), 5000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.cancel_campaign(&campaign_id);
+
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 2000);
+
+    let res = client.try_claim_refund(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+    assert_eq!(token.balance(&contributor1), 2000);
+}
+
+#[test]
+fn test_refund_requires_deadline_passed_and_goal_missed() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Failed Campaign"),
+        String::from_str(&env, "Desc"), 10_000, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    let res = client.try_claim_refund(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+}
+
+#[test]
+fn test_no_refund_when_goal_reached() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Successful Campaign"),
+        String::from_str(&env, "Desc"), 500, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_claim_refund(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}

--- a/src/tests/test_refund_edge.rs
+++ b/src/tests/test_refund_edge.rs
@@ -1,0 +1,125 @@
+use super::helpers::*;
+use crate::{Category, CreateCampaignParams, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_claim_refund_state_mutation_order() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Refund Order Test"),
+        String::from_str(&env, "Testing state mutation order"), 10000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.cancel_campaign(&campaign_id);
+
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 1000);
+    assert_eq!(token.balance(&contributor1), 4000);
+    assert_eq!(token.balance(&client.address), 1000);
+
+    client.claim_refund(&campaign_id, &contributor1);
+
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+    assert_eq!(token.balance(&contributor1), 5000);
+    assert_eq!(token.balance(&client.address), 0);
+
+    let res = client.try_claim_refund(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+}
+
+#[test]
+fn test_claim_refund_multiple_contributors_isolation() {
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&contributor2, &3000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Multi Refund Test"),
+        String::from_str(&env, "Testing multiple refunds"), 10000, 10,
+        Category::Learner, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &2000);
+    client.contribute(&campaign_id, &contributor2, &1500);
+    client.cancel_campaign(&campaign_id);
+
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+    assert_eq!(token.balance(&contributor1), 5000);
+
+    assert_eq!(client.get_contribution(&campaign_id, &contributor2), 1500);
+    assert_eq!(token.balance(&contributor2), 1500);
+
+    client.claim_refund(&campaign_id, &contributor2);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor2), 0);
+    assert_eq!(token.balance(&contributor2), 3000);
+}
+
+#[test]
+fn test_claim_refund_expired_campaign() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+
+    let duration_days = 2;
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Expired Campaign"),
+        String::from_str(&env, "Will expire"), 10000, duration_days,
+        Category::Learner, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: env.ledger().timestamp() + (duration_days * 86450),
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 0);
+    assert_eq!(token.balance(&contributor1), 5000);
+    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
+}
+
+#[test]
+fn test_claim_refund_clears_existing_revenue_claimed_key() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10_000);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Refund Cleans Revenue Claim"),
+        description: String::from_str(&env, "Ensure RevenueClaimed key is removed"),
+        funding_goal: 5000,
+        duration_days: 30,
+        category: Category::EducationalStartup,
+        has_revenue_sharing: true,
+        revenue_share_percentage: 2000,
+        max_contribution_per_user: 0i128,
+    });
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.deposit_revenue(&campaign_id, &1000);
+    client.claim_revenue(&campaign_id, &contributor1);
+
+    let claimed_before_refund = client.get_revenue_claimed(&campaign_id, &contributor1);
+    assert!(claimed_before_refund > 0);
+
+    client.cancel_campaign(&campaign_id);
+    client.claim_refund(&campaign_id, &contributor1);
+
+    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
+}

--- a/src/tests/test_revenue.rs
+++ b/src/tests/test_revenue.rs
@@ -1,0 +1,170 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_pull_based_revenue_distribution() {
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &1000);
+    token_admin.mint(&contributor2, &1000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Next Gen AI"),
+        String::from_str(&env, "Build AI"), 2000, 30,
+        Category::EducationalStartup, true, 2000, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.contribute(&campaign_id, &contributor2, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    token_admin.mint(&creator, &5000);
+    client.deposit_revenue(&campaign_id, &5000);
+    assert_eq!(client.get_revenue_pool(&campaign_id), 5000);
+
+    client.claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 500);
+    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 500);
+
+    client.deposit_revenue(&campaign_id, &1000);
+    assert_eq!(client.get_revenue_pool(&campaign_id), 6000);
+
+    client.claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 600);
+
+    client.claim_revenue(&campaign_id, &contributor2);
+    assert_eq!(token.balance(&contributor2), 600);
+}
+
+#[test]
+fn test_revenue_sharing_edge_cases() {
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    let campaign_nr = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "No Revenue"),
+        String::from_str(&env, "Non-revenue campaign"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_nr);
+    let res = client.try_claim_revenue(&campaign_nr, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    token_admin.mint(&contributor1, &10);
+    token_admin.mint(&contributor2, &10);
+    token_admin.mint(&creator, &100);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Rounding Test"),
+        String::from_str(&env, "Test rounding and pool edge cases"), 3, 30,
+        Category::EducationalStartup, true, 5000, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1);
+    client.contribute(&campaign_id, &contributor2, &2);
+    client.withdraw_funds(&campaign_id);
+
+    let res = client.try_claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+
+    client.deposit_revenue(&campaign_id, &10);
+    client.claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 10);
+
+    client.claim_revenue(&campaign_id, &contributor2);
+    assert_eq!(token.balance(&contributor2), 11);
+
+    let res = client.try_claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+}
+
+#[test]
+fn test_claim_revenue_requires_contributor_auth() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Revenue Claim Auth"),
+        String::from_str(&env, "Testing claim revenue auth"), 1000, 10,
+        Category::EducationalStartup, true, 1000, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    token_admin.mint(&creator, &5000);
+    client.deposit_revenue(&campaign_id, &5000);
+
+    env.mock_all_auths();
+    client.claim_revenue(&campaign_id, &contributor1);
+
+    let auths = env.auths();
+    let found = auths.iter().any(|(addr, inv)| {
+        *addr == contributor1
+            && match &inv.function {
+                soroban_sdk::testutils::AuthorizedFunction::Contract((contract, function, _)) => {
+                    contract == &client.address
+                        && function == &soroban_sdk::Symbol::new(&env, "claim_revenue")
+                }
+                _ => false,
+            }
+    });
+    assert!(found);
+}
+
+#[test]
+fn test_revenue_lifecycle_e2e() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&contributor2, &3000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Revenue Sharing Campaign"),
+        String::from_str(&env, "Full lifecycle test: create, fund, withdraw, deposit revenue, claim"),
+        6000, 30, Category::EducationalStartup, true, 2000, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &4000);
+    client.contribute(&campaign_id, &contributor2, &2500);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.amount_raised, 6500);
+    assert!(campaign.amount_raised >= campaign.funding_goal);
+
+    client.withdraw_funds(&campaign_id);
+
+    let campaign_after_withdrawal = client.get_campaign(&campaign_id);
+    assert!(campaign_after_withdrawal.funds_withdrawn);
+    assert!(!campaign_after_withdrawal.is_active);
+
+    token_admin.mint(&creator, &10000);
+    client.deposit_revenue(&campaign_id, &10000);
+    assert_eq!(client.get_revenue_pool(&campaign_id), 10000);
+
+    let contrib1_claimed_before = client.get_revenue_claimed(&campaign_id, &contributor1);
+    client.claim_revenue(&campaign_id, &contributor1);
+    let contrib1_claimed_after = client.get_revenue_claimed(&campaign_id, &contributor1);
+    assert!(contrib1_claimed_after > contrib1_claimed_before);
+
+    let contrib2_claimed_before = client.get_revenue_claimed(&campaign_id, &contributor2);
+    client.claim_revenue(&campaign_id, &contributor2);
+    let contrib2_claimed_after = client.get_revenue_claimed(&campaign_id, &contributor2);
+    assert!(contrib2_claimed_after > contrib2_claimed_before);
+
+    client.claim_creator_revenue(&campaign_id);
+
+    assert!(client.try_claim_revenue(&campaign_id, &contributor1).is_err());
+    assert!(client.try_claim_revenue(&campaign_id, &contributor2).is_err());
+
+    assert!(!env.events().all().is_empty());
+}

--- a/src/tests/test_revenue_deposit.rs
+++ b/src/tests/test_revenue_deposit.rs
@@ -1,0 +1,125 @@
+use super::helpers::*;
+use crate::{Category, CreateCampaignParams, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_deposit_revenue_negative_amount() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Startup"),
+        String::from_str(&env, "Revenue sharing startup"), 1000, 30,
+        Category::EducationalStartup, true, 2000, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let res = client.try_deposit_revenue(&campaign_id, &-100);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_deposit_revenue_zero_amount() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Startup"),
+        String::from_str(&env, "Revenue sharing startup"), 1000, 30,
+        Category::EducationalStartup, true, 2000, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let res = client.try_deposit_revenue(&campaign_id, &0);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_deposit_revenue_without_revenue_sharing() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Educator Campaign"),
+        String::from_str(&env, "No revenue sharing"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let res = client.try_deposit_revenue(&campaign_id, &1000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::RevenueSharingNotEnabled);
+}
+
+#[test]
+fn test_deposit_revenue_when_paused() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Startup"),
+        String::from_str(&env, "Revenue sharing startup"), 1000, 30,
+        Category::EducationalStartup, true, 2000, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    client.pause();
+
+    let res = client.try_deposit_revenue(&campaign_id, &1000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContractPaused);
+}
+
+#[test]
+fn test_deposit_revenue_non_existent_campaign() {
+    let (_env, _admin, _creator, _, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&_admin, &10000);
+
+    let res = client.try_deposit_revenue(&999, &1000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_deposit_revenue_repeated_calls_accumulate_and_emit_events() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &10_000);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Repeated Deposits"),
+        description: String::from_str(&env, "Deposit idempotency"),
+        funding_goal: 1000,
+        duration_days: 30,
+        category: Category::EducationalStartup,
+        has_revenue_sharing: true,
+        revenue_share_percentage: 2000,
+        max_contribution_per_user: 0i128,
+    });
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let events_before = env.events().all().len();
+    for _ in 0..10 {
+        client.deposit_revenue(&campaign_id, &100);
+    }
+    let events_after = env.events().all().len();
+    assert_eq!(client.get_revenue_pool(&campaign_id), 1000);
+    assert_eq!(events_after - events_before, 20);
+}

--- a/src/tests/test_voting.rs
+++ b/src/tests/test_voting.rs
@@ -1,0 +1,237 @@
+use super::helpers::*;
+use crate::{Category, CreateCampaignParams, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_community_voting_verification_success() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Community Verified"),
+        String::from_str(&env, "Verify by voting"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &false);
+
+    assert_eq!(client.get_approve_votes(&campaign_id), 2);
+    assert_eq!(client.get_reject_votes(&campaign_id), 1);
+    assert!(client.has_voted(&campaign_id, &contributor1));
+
+    client.verify_campaign_with_votes(&campaign_id);
+    let campaign = client.get_campaign(&campaign_id);
+    assert!(campaign.is_verified);
+
+    let res = client.try_verify_campaign_with_votes(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CommunityVerificationConflict);
+}
+
+#[test]
+fn test_vote_prevents_double_voting_and_requires_token_holder() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    let non_holder = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Vote Safety"),
+        String::from_str(&env, "No duplicate votes"), 500, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &false);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyVoted);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &non_holder, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotTokenHolder);
+}
+
+#[test]
+fn test_verify_campaign_quorum_and_threshold_edges() {
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+    let voter3 = Address::generate(&env);
+    let voter4 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+    token_admin.mint(&voter4, &100);
+
+    client.set_voting_params(&admin, &4, &7500);
+    assert_eq!(client.get_min_votes_quorum(), 4);
+    assert_eq!(client.get_approval_threshold_bps(), 7500);
+
+    let campaign_id_1 = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Quorum Campaign"),
+        String::from_str(&env, "Needs 4 votes"), 700, 30,
+        Category::Publisher, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id_1, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id_1, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id_1, &voter3, &true);
+
+    let res = client.try_verify_campaign_with_votes(&campaign_id_1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingQuorumNotMet);
+
+    client.vote_on_campaign(&campaign_id_1, &voter4, &false);
+    client.verify_campaign(&campaign_id_1);
+    assert!(client.get_campaign(&campaign_id_1).is_verified);
+
+    let campaign_id_2 = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Threshold Campaign"),
+        String::from_str(&env, "Fails threshold"), 700, 30,
+        Category::Publisher, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id_2, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id_2, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id_2, &voter3, &false);
+    client.vote_on_campaign(&campaign_id_2, &voter4, &false);
+
+    let res = client.try_verify_campaign_with_votes(&campaign_id_2);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingThresholdNotMet);
+}
+
+#[test]
+fn test_set_voting_params_rejects_threshold_over_10000() {
+    let (_env, admin, _, _, _, _, _, client) = setup_env();
+
+    let res = client.try_set_voting_params(&admin, &3, &10000);
+    assert!(res.is_ok());
+
+    let res = client.try_set_voting_params(&admin, &3, &10001);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    let res = client.try_set_voting_params(&admin, &3, &u32::MAX);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_set_voting_params_rejects_non_admin() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let res = client.try_set_voting_params(&creator, &5, &7000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+
+    let random = Address::generate(&env);
+    let res = client.try_set_voting_params(&random, &5, &7000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}
+
+#[test]
+fn test_set_voting_params_emits_event() {
+    let (env, admin, _, _, _, _, _, client) = setup_env();
+
+    client.set_voting_params(&admin, &5, &7000);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    let topics = &last_event.1;
+    assert_eq!(topics.len(), 2);
+
+    let data: (u32, u32, u32, u32) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(data, (3, 5, 6000, 7000));
+}
+
+#[test]
+fn test_vote_on_campaign_basic_flow() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &1000);
+    token_admin.mint(&contributor2, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Voting Test"),
+        String::from_str(&env, "Test voting"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(client.get_approve_votes(&campaign_id), 1);
+    assert_eq!(client.get_reject_votes(&campaign_id), 0);
+    assert!(client.has_voted(&campaign_id, &contributor1));
+
+    client.vote_on_campaign(&campaign_id, &contributor2, &false);
+    assert_eq!(client.get_approve_votes(&campaign_id), 1);
+    assert_eq!(client.get_reject_votes(&campaign_id), 1);
+    assert!(client.has_voted(&campaign_id, &contributor2));
+}
+
+#[test]
+fn test_vote_on_campaign_double_vote_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Double Vote Test"),
+        String::from_str(&env, "Test double voting"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &false);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AlreadyVoted);
+}
+
+#[test]
+fn test_vote_on_campaign_no_tokens_fails() {
+    let (env, _admin, creator, contributor1, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "No Token Vote Test"),
+        String::from_str(&env, "Test voting without tokens"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotTokenHolder);
+}
+
+#[test]
+fn test_vote_on_campaign_below_minimum_balance_fails() {
+    let (env, admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &100);
+    client.set_min_voting_balance(&admin, &500);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Min Balance Vote Test"),
+        String::from_str(&env, "Test voting with insufficient balance"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotTokenHolder);
+}
+
+#[test]
+fn test_vote_on_verified_campaign_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Already Verified"),
+        String::from_str(&env, "Test voting on verified campaign"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.verify_campaign(&campaign_id);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+}

--- a/src/tests/test_voting_verify.rs
+++ b/src/tests/test_voting_verify.rs
@@ -1,0 +1,211 @@
+use super::helpers::*;
+use crate::{Category, CreateCampaignParams, Error};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_vote_on_cancelled_campaign_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Cancelled Campaign"),
+        String::from_str(&env, "Test voting on cancelled campaign"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.cancel_campaign(&campaign_id);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_vote_on_campaign_past_deadline_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &1000);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Deadline Vote"),
+        description: String::from_str(&env, "Voting deadline gate"),
+        funding_goal: 1000,
+        duration_days: 1,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0i128,
+    });
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_vote_on_campaign_after_withdraw_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Withdrawn Vote"),
+        description: String::from_str(&env, "Voting withdrawn gate"),
+        funding_goal: 1000,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0i128,
+    });
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_vote_on_campaign_token_weighted() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&contributor2, &1000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Weighted Vote Test"),
+        String::from_str(&env, "Test token-weighted voting"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &false);
+
+    assert_eq!(client.get_approve_votes(&campaign_id), 1);
+    assert_eq!(client.get_reject_votes(&campaign_id), 1);
+}
+
+#[test]
+fn test_verify_campaign_with_votes_quorum_not_met() {
+    let (env, admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &1000);
+    client.set_voting_params(&admin, &5, &6000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Quorum Test"),
+        String::from_str(&env, "Test quorum requirement"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+
+    let res = client.try_verify_campaign_with_votes(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingQuorumNotMet);
+}
+
+#[test]
+fn test_verify_campaign_with_votes_threshold_not_met() {
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &1000);
+    token_admin.mint(&contributor2, &1000);
+    let voter3 = Address::generate(&env);
+    token_admin.mint(&voter3, &1000);
+
+    client.set_voting_params(&admin, &3, &8000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Threshold Test"),
+        String::from_str(&env, "Test approval threshold"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &false);
+
+    let res = client.try_verify_campaign_with_votes(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::VotingThresholdNotMet);
+}
+
+#[test]
+fn test_verify_campaign_with_votes_success() {
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &1000);
+    token_admin.mint(&contributor2, &1000);
+    let voter3 = Address::generate(&env);
+    token_admin.mint(&voter3, &1000);
+
+    client.set_voting_params(&admin, &3, &6000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Success Verify Test"),
+        String::from_str(&env, "Test successful verification"), 1000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &false);
+
+    client.verify_campaign_with_votes(&campaign_id);
+
+    assert!(client.get_campaign(&campaign_id).is_verified);
+}
+
+#[test]
+fn test_vote_on_nonexistent_campaign() {
+    let (_env, _admin, _creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &1000);
+
+    let res = client.try_vote_on_campaign(&999, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_min_voting_balance_threshold_enforcement() {
+    let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &50);
+    token_admin.mint(&contributor2, &200);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Min Balance Vote Test"),
+        String::from_str(&env, "Testing minimum voting balance"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    client.set_min_voting_balance(&admin, &100);
+    assert_eq!(client.get_min_voting_balance(), 100);
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotTokenHolder);
+
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    assert!(client.has_voted(&campaign_id, &contributor2));
+    assert_eq!(client.get_approve_votes(&campaign_id), 1);
+
+    client.set_min_voting_balance(&admin, &0);
+    assert_eq!(client.get_min_voting_balance(), 0);
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert!(client.has_voted(&campaign_id, &contributor1));
+    assert_eq!(client.get_approve_votes(&campaign_id), 2);
+}

--- a/src/tests/test_withdraw.rs
+++ b/src/tests/test_withdraw.rs
@@ -1,0 +1,123 @@
+use super::helpers::*;
+use crate::{storage, Category, DataKey, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_withdraw_before_deadline_goal_not_met_fails() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Early Withdraw"),
+        String::from_str(&env, "Desc"), 10_000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    let res = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalNotReached);
+}
+
+#[test]
+fn test_withdraw_after_deadline_goal_not_met_returns_typed_error() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Late Withdraw"),
+        String::from_str(&env, "Desc"), 10_000, 1,
+        Category::Learner, false, 0, 0i128,
+    ));
+    let _ = client.try_verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    let deadline = client.get_campaign(&campaign_id).deadline;
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: deadline + 1,
+        protocol_version: 22,
+        sequence_number: env.ledger().sequence(),
+        network_id: [0; 32],
+        base_reserve: 10,
+        min_temp_entry_ttl: 10,
+        min_persistent_entry_ttl: 10,
+        max_entry_ttl: 10,
+    });
+
+    let res = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalNotReached);
+}
+
+#[test]
+fn test_withdraw_funds_requires_verified_campaign() {
+    let (env, _admin, creator, _contributor1, _, _token, token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Unverified Campaign"),
+        String::from_str(&env, "Description"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+
+    let contract_id = env.register_contract(None, crate::ProofOfHeart);
+    token_admin.mint(&contract_id, &1500);
+    env.as_contract(&client.address, || {
+        let mut campaign = storage::get_campaign(&env, campaign_id).unwrap();
+        campaign.amount_raised = 1500;
+        storage::set_campaign(&env, campaign_id, &campaign);
+    });
+
+    let result = client.try_withdraw_funds(&campaign_id);
+    assert_eq!(result.unwrap_err().unwrap(), Error::CampaignNotVerified);
+}
+
+#[test]
+fn test_withdraw_funds_succeeds_when_verified() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Verified Campaign"),
+        String::from_str(&env, "Description"), 1000, 30,
+        Category::Educator, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1500);
+
+    assert!(client.try_withdraw_funds(&campaign_id).is_ok());
+}
+
+#[test]
+fn test_claim_refund_removes_contribution_storage_key() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5_000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(), String::from_str(&env, "Refund storage cleanup"),
+        String::from_str(&env, "Contribution key should be removed"), 5_000, 30,
+        Category::Learner, false, 0, 0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1_000);
+    client.cancel_campaign(&campaign_id);
+
+    env.as_contract(&client.address, || {
+        assert!(env.storage().persistent()
+            .has(&DataKey::Contribution(campaign_id, contributor1.clone())));
+    });
+
+    client.claim_refund(&campaign_id, &contributor1);
+
+    env.as_contract(&client.address, || {
+        assert!(!env.storage().persistent()
+            .has(&DataKey::Contribution(campaign_id, contributor1.clone())));
+    });
+}
+
+#[test]
+fn test_view_function_get_campaign_not_found() {
+    let (_env, _admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    let res = client.try_get_campaign(&999);
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -60,6 +60,10 @@ pub struct Campaign {
     pub revenue_share_percentage: u32,
     /// Maximum tokens a single contributor may contribute in total. 0 means no cap.
     pub max_contribution_per_user: i128,
+    /// Per-campaign platform fee override in basis points. None = use global fee.
+    pub fee_override: Option<u32>,
+    /// Whether the deadline has already been extended once.
+    pub deadline_extended: bool,
 }
 
 /// Aggregate platform metrics for dashboard and indexer consumers.


### PR DESCRIPTION
## Summary

Implements four GitHub issues in a minimal, focused way:

- **Closes #192** — Per-campaign platform fee override: `fee_override: Option<u32>` field on `Campaign`; admin-only `set_campaign_fee_override(campaign_id, fee_bps)` (max 1000 bps); `withdraw_funds` consults the override and falls back to the global fee.
- **Closes #200** — Per-category duration cap: `CategoryDurationCap` storage key per category; admin-only `set_category_duration_cap(category, max_days)` (max 365); `create_campaign` validates against the cap, defaulting to 365 when none is set.
- **Closes #193** — Creator deadline extension: `deadline_extended: bool` on `Campaign`; `extend_campaign_deadline(campaign_id, additional_days)` — max one extension, max 30 extra days, only before original deadline; emits `campaign_deadline_extended` event.
- **Closes #220** — Replaced the 3660-line `src/test.rs` with 17 focused modules under `src/tests/`, each under 300 lines, with a shared `helpers.rs`. All 256 tests still pass.

## Test plan

- [ ] `cargo test` — 256 passed, 0 failed
- [ ] All new features covered by dedicated test files: `test_fee_override.rs`, `test_duration_cap.rs`, `test_deadline_ext.rs`
- [ ] Every test module is under 300 lines

EOF
)" 