### PR TITLE
fix: bounds clamp, auth ordering, event payload, and refund revenue test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1117,7 +1117,7 @@ impl ProofOfHeart {
             return campaigns;
         }
 
-        let end = start + capped_limit;
+        let end = (start + capped_limit).min(total);
         let num_buckets = (total + CREATOR_CAMPAIGNS_BUCKET_SIZE - 1) / CREATOR_CAMPAIGNS_BUCKET_SIZE;
         let mut global_idx = 0u32;
 
@@ -1745,13 +1745,14 @@ impl ProofOfHeart {
     /// Requires `pending_creator.require_auth()`.
     pub fn accept_campaign_transfer(env: Env, campaign_id: u32) -> Result<(), Error> {
         let mut campaign = get_campaign_or_error(&env, campaign_id)?;
-        Self::require_not_paused(&env)?;
 
         let pending = match campaign.pending_creator.clone() {
             MaybePendingCreator::Some(addr) => addr,
             MaybePendingCreator::None => return Err(Error::NoTransferPending),
         };
         pending.require_auth();
+
+        Self::require_not_paused(&env)?;
 
         bump_instance_ttl(&env);
         let old_creator = campaign.creator.clone();
@@ -1841,16 +1842,17 @@ impl ProofOfHeart {
         let mut campaign = get_creator_campaign(&env, campaign_id)?;
         Self::require_not_paused(&env)?;
 
-        if campaign.pending_creator == MaybePendingCreator::None {
-            return Err(Error::NoTransferPending);
-        }
+        let pending_address = match campaign.pending_creator.clone() {
+            MaybePendingCreator::Some(addr) => addr,
+            MaybePendingCreator::None => return Err(Error::NoTransferPending),
+        };
 
         bump_instance_ttl(&env);
         campaign.pending_creator = MaybePendingCreator::None;
         set_campaign(&env, campaign_id, &campaign);
 
         env.events()
-            .publish(("campaign_transfer_cancelled", campaign_id), ());
+            .publish(("campaign_transfer_cancelled", campaign_id), pending_address);
 
         Ok(())
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -3982,3 +3982,78 @@ fn test_verify_campaigns_extends_voting_state_ttl() {
     let campaign = client.get_campaign(&campaign_id);
     assert!(campaign.is_verified);
 }
+
+// Issue #300: verify no panics when claim_revenue / claim_creator_revenue are called
+// after all contributors have been refunded (contribution entries removed from storage).
+#[test]
+fn test_revenue_claim_after_full_refunds_no_panic() {
+    let (env, _admin, creator, contributor1, _, token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5_000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Revenue Refund Test"),
+        String::from_str(&env, "Testing revenue claim after full refund"),
+        1_000,
+        30,
+        Category::EducationalStartup,
+        true,
+        2000, // 20% revenue share
+        0i128,
+    ));
+
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    // Cancel so the contributor is eligible for a refund
+    client.cancel_campaign(&campaign_id);
+
+    // Contributor claims full refund — removes their contribution entry
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(token.balance(&contributor1), 5_000);
+
+    // claim_revenue must not panic; contribution is 0 so expect ValidationFailed
+    let res = client.try_claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    // claim_creator_revenue must not panic; no revenue deposited so expect NoFundsToWithdraw
+    let res = client.try_claim_creator_revenue(&campaign_id);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);
+}
+
+// Directly exercises the AmountRaisedIsZero guard in claim_revenue by forcing
+// amount_raised = 0 on the campaign struct while a contribution is still present.
+// This is an artificial state that cannot arise in normal contract flow, but it
+// confirms the guard fires and returns an error rather than dividing by zero.
+#[test]
+fn test_claim_revenue_amount_raised_zero_guard() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5_000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Zero Raised Guard"),
+        String::from_str(&env, "Directly test AmountRaisedIsZero guard"),
+        1_000,
+        30,
+        Category::EducationalStartup,
+        true,
+        2000,
+        0i128,
+    ));
+
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &500);
+
+    // Artificially zero out amount_raised while keeping the contribution in storage
+    env.as_contract(&client.address, || {
+        let mut campaign = get_campaign(&env, campaign_id).unwrap();
+        campaign.amount_raised = 0;
+        set_campaign(&env, campaign_id, &campaign);
+    });
+
+    let res = client.try_claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::AmountRaisedIsZero);
+}


### PR DESCRIPTION
closes #303 - Clamp the `end` index in `get_creator_campaigns` with `.min(total)` so a
page request that overshoots the last item returns a partial/empty result instead of panicking.

closes #302 - Move `pending.require_auth()` in `accept_campaign_transfer` to immediately
after the pending address is resolved, before `require_not_paused`, following the auth-first pattern recommended by Stellar docs.

closes #299 - Extract the pending transferee address before clearing it in
`cancel_campaign_transfer` and include it as the event data payload, enabling indexers to build a complete transfer audit trail from events alone.

closes #300 - Add two tests covering revenue claims after full refunds: one that walks the
full cancel-and-refund flow asserting no panics, and one that directly exercises the `AmountRaisedIsZero` guard via storage manipulation to confirm no divide-by-zero trap.
