### PR TITLE
fix: enforce minimum floor of 10% on approval_threshold_bps

### DIFF
--- a/src/voting.rs
+++ b/src/voting.rs
@@ -18,6 +18,10 @@ pub const MAX_VOTES_QUORUM: u32 = 1000;
 /// Default approval threshold in basis points (60%).
 pub const DEFAULT_APPROVAL_THRESHOLD_BPS: u32 = 6000;
 
+/// Minimum allowed approval threshold in basis points (10%).
+/// Prevents governance misconfiguration where near-zero threshold bypasses community review.
+pub const MIN_APPROVAL_THRESHOLD_BPS: u32 = 1000;
+
 /// Updates the community voting parameters.
 ///
 /// # Errors
@@ -29,7 +33,7 @@ pub fn set_params(
     min_votes_quorum: u32,
     approval_threshold_bps: u32,
 ) -> Result<(), Error> {
-    if min_votes_quorum == 0 || min_votes_quorum > MAX_VOTES_QUORUM || approval_threshold_bps == 0 || approval_threshold_bps > 10000 {
+    if min_votes_quorum == 0 || min_votes_quorum > MAX_VOTES_QUORUM || approval_threshold_bps < MIN_APPROVAL_THRESHOLD_BPS || approval_threshold_bps > 10000 {
         return Err(Error::ValidationFailed);
     }
     set_min_votes_quorum(env, min_votes_quorum);


### PR DESCRIPTION
Closes #326

Adds `MIN_APPROVAL_THRESHOLD_BPS = 1000` (10%) constant and changes the validation in `set_params` from `== 0` to `< MIN_APPROVAL_THRESHOLD_BPS`, preventing a value like `1` (0.01%) from bypassing community governance.