### PR TITLE
fix: resolve issues #319, #320, #321, #325

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,12 @@ impl ProofOfHeart {
         }
 
         let total_raised = get_total_raised_global(&env);
-        set_total_raised_global(&env, total_raised - campaign.amount_raised);
+        set_total_raised_global(
+            &env,
+            total_raised
+                .checked_sub(campaign.amount_raised)
+                .ok_or(Error::Overflow)?,
+        );
 
         env.events().publish(
             ("withdrawal", campaign_id, campaign.creator.clone()),
@@ -723,7 +728,12 @@ impl ProofOfHeart {
         decrement_contributor_count(&env, campaign_id);
 
         let total_raised = get_total_raised_global(&env);
-        set_total_raised_global(&env, total_raised - amount);
+        set_total_raised_global(
+            &env,
+            total_raised
+                .checked_sub(amount)
+                .ok_or(Error::Overflow)?,
+        );
 
         let client = Self::token_client(&env);
         client.transfer(&env.current_contract_address(), &contributor, &amount);
@@ -749,6 +759,10 @@ impl ProofOfHeart {
             return Err(Error::CampaignNotActive);
         }
         require_revenue_sharing(&campaign, Error::RevenueSharingNotEnabled)?;
+
+        if campaign.amount_raised == 0 {
+            return Err(Error::AmountRaisedIsZero);
+        }
 
         bump_instance_ttl(&env);
         let token_addr = get_token(&env);
@@ -1721,6 +1735,7 @@ impl ProofOfHeart {
             verified_campaigns,
             cancelled_campaigns,
             total_amount_raised: get_total_raised_global(&env),
+            is_partial: total_campaigns > MAX_SCAN_LIMIT,
         }
     }
 
@@ -1841,10 +1856,16 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
-        remove_voting_state(&env, campaign_id);
+        // Cap batch size to prevent compute budget exhaustion
+        const MAX_PURGE_BATCH: u32 = 100;
+        if voters.len() > MAX_PURGE_BATCH {
+            return Err(Error::ValidationFailed);
+        }
+
         for voter in voters.iter() {
             remove_has_voted(&env, campaign_id, &voter);
         }
+        remove_voting_state(&env, campaign_id);
 
         env.events()
             .publish(("voting_state_purged", campaign_id), ());

--- a/src/types.rs
+++ b/src/types.rs
@@ -82,6 +82,9 @@ pub struct PlatformStats {
     pub cancelled_campaigns: u32,
     /// Sum of `amount_raised` across all campaigns.
     pub total_amount_raised: i128,
+    /// Whether the counts are partial due to scan limit. When true,
+    /// active/verified/cancelled counts may not reflect all campaigns.
+    pub is_partial: bool,
 }
 
 /// Parameters for `create_campaign`, grouped into a single struct to avoid


### PR DESCRIPTION
## Summary

### #319 - deposit_revenue accepts tokens when campaign.amount_raised == 0
Added a guard in `deposit_revenue` that returns `Error::AmountRaisedIsZero` when `campaign.amount_raised == 0`, preventing permanently locked tokens.

### #320 - purge_voting_state accepts unbounded voters Vec
Added a `MAX_PURGE_BATCH = 100` cap on the `voters` parameter and moved `remove_voting_state` after the per-voter loop for atomicity (either everything succeeds or nothing changes).

### #321 - withdraw_funds subtracts campaign.amount_raised without overflow check
Applied `checked_sub` with `Error::Overflow` in both `withdraw_funds` and `claim_refund` to prevent silent underflow on `total_raised_global`.

### #325 - get_platform_stats silently truncates at 1000 campaigns
Added an `is_partial: bool` field to `PlatformStats` that is set to `true` when `total_campaigns > MAX_SCAN_LIMIT`, allowing callers to detect truncated results.

Closes #319
Closes #320 
Closes #321 
Closes #325