### PR TITLE
fix(contract): fee validation, overflow protection, cap guard, and TTL side-effect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,7 +1330,8 @@ impl ProofOfHeart {
         if amount < 0 {
             return Err(Error::ValidationFailed);
         }
-        let _campaign = get_campaign_or_error(&env, campaign_id)?;
+        let campaign = get_campaign_or_error(&env, campaign_id)?;
+        require_active_campaign(&campaign)?;
         bump_instance_ttl(&env);
         set_personal_cap(&env, campaign_id, &contributor, amount);
         env.events().publish(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1188,15 +1188,13 @@ impl ProofOfHeart {
         let admin = get_admin(&env);
         assert_admin(&env, &admin)?;
         Self::require_not_paused(&env)?;
-        let valid_fee = if new_fee > PLATFORM_FEE_MAX_BPS {
-            PLATFORM_FEE_MAX_BPS
-        } else {
-            new_fee
-        };
+        if new_fee > PLATFORM_FEE_MAX_BPS {
+            return Err(Error::ValidationFailed);
+        }
         let old_fee = get_platform_fee(&env);
         bump_instance_ttl(&env);
-        set_platform_fee(&env, valid_fee);
-        env.events().publish(("fee_updated",), (old_fee, valid_fee));
+        set_platform_fee(&env, new_fee);
+        env.events().publish(("fee_updated",), (old_fee, new_fee));
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1643,11 +1643,8 @@ impl ProofOfHeart {
             return campaigns;
         }
 
-        let end = if offset + limit > total {
-            total
-        } else {
-            offset + limit
-        };
+        let capped_limit = limit.min(LIST_MAX_LIMIT);
+        let end = offset.saturating_add(capped_limit).min(total);
 
         let mut position = offset;
         while position < end {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,7 +629,6 @@ impl ProofOfHeart {
 
         require_active_campaign(&campaign)?;
 
-        bump_instance_ttl(&env);
         if title.len() < CAMPAIGN_TITLE_MIN_LEN || title.len() > CAMPAIGN_TITLE_MAX_LEN {
             return Err(Error::ValidationFailed);
         }
@@ -639,6 +638,7 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
+        bump_instance_ttl(&env);
         campaign.title = title.clone();
         campaign.description = description;
 


### PR DESCRIPTION
## Summary

- **#316** — `update_platform_fee` now returns `Error::ValidationFailed` when `new_fee > PLATFORM_FEE_MAX_BPS` instead of silently clamping. Admin tooling receives an explicit error and the event log records only the intended value.
- **#317** — `get_campaigns_by_category` now applies the `LIST_MAX_LIMIT` cap and uses `saturating_add` for the end-index calculation, eliminating the `u32` overflow wrapping vulnerability.
- **#318** — `set_personal_cap` now calls `require_active_campaign` after campaign retrieval, returning `Error::CampaignNotActive` for cancelled or withdrawn campaigns and preventing orphaned ledger entries.
- **#328** — `update_campaign` now runs all title/description length validations before calling `bump_instance_ttl`, ensuring TTL is never extended by an invalid request.

Closes #316
Closes #317
Closes #318
Closes #328

## Test plan

- [ ] Call `update_platform_fee` with `new_fee = 2000` → expect `ValidationFailed` (not silent clamp to 1000)
- [ ] Call `get_campaigns_by_category` with `offset = u32::MAX - 1, limit = u32::MAX` → expect empty result, no panic
- [ ] Call `set_personal_cap` on a cancelled campaign → expect `CampaignNotActive`
- [ ] Call `update_campaign` with a title exceeding max length → verify no TTL bump occurs (ledger cost unchanged)