### PR TITLE
fix: reject silent overwrite of pending campaign transfer (#340)

### DIFF
--- a/src/campaign_transfer_test.rs
+++ b/src/campaign_transfer_test.rs
@@ -37,7 +37,7 @@ fn create_campaign(
 }
 
 #[test]
-fn campaign_transfer_reinitiate_replaces_pending_owner() {
+fn campaign_transfer_reinitiate_rejects_silent_overwrite() {
     let (env, _admin, creator, client) = setup_env();
     let pending_one = Address::generate(&env);
     let pending_two = Address::generate(&env);
@@ -46,22 +46,24 @@ fn campaign_transfer_reinitiate_replaces_pending_owner() {
     client.initiate_campaign_transfer(&campaign_id, &pending_one);
     assert_eq!(
         client.get_campaign(&campaign_id).pending_creator,
-        MaybePendingCreator::Some(pending_one)
+        MaybePendingCreator::Some(pending_one.clone())
     );
 
-    client.initiate_campaign_transfer(&campaign_id, &pending_two);
+    let res = client.try_initiate_campaign_transfer(&campaign_id, &pending_two);
+    assert_eq!(res.unwrap_err().unwrap(), Error::TransferAlreadyPending);
 
+    // First pending recipient is preserved and can still accept.
     let campaign = client.get_campaign(&campaign_id);
     assert_eq!(campaign.creator, creator);
     assert_eq!(
         campaign.pending_creator,
-        MaybePendingCreator::Some(pending_two.clone())
+        MaybePendingCreator::Some(pending_one.clone())
     );
 
     client.accept_campaign_transfer(&campaign_id);
 
     let transferred = client.get_campaign(&campaign_id);
-    assert_eq!(transferred.creator, pending_two);
+    assert_eq!(transferred.creator, pending_one);
     assert_eq!(transferred.pending_creator, MaybePendingCreator::None);
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -81,4 +81,6 @@ pub enum Error {
     ExtensionTooLong = 37,
     /// The funding goal exceeds the configured maximum (anti-spam cap).
     FundingGoalTooHigh = 38,
+    /// A campaign transfer is already pending; cancel it before initiating a new one.
+    TransferAlreadyPending = 39,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1739,6 +1739,11 @@ impl ProofOfHeart {
     ///
     /// # Authorization
     /// Requires `campaign.creator.require_auth()`.
+    ///
+    /// # Errors
+    /// * `TransferAlreadyPending` - A pending transfer already exists; the creator
+    ///   must call `cancel_campaign_transfer` before initiating a new one. This
+    ///   prevents silently overwriting an outstanding recipient.
     pub fn initiate_campaign_transfer(
         env: Env,
         campaign_id: u32,
@@ -1749,6 +1754,10 @@ impl ProofOfHeart {
 
         if new_creator == campaign.creator {
             return Err(Error::InvalidNewOwner);
+        }
+
+        if campaign.pending_creator != MaybePendingCreator::None {
+            return Err(Error::TransferAlreadyPending);
         }
 
         bump_instance_ttl(&env);


### PR DESCRIPTION
## Summary
- `initiate_campaign_transfer` silently replaced an outstanding `pending_creator` with no error, no event, and no signal to the first intended recipient. A creator could repeatedly call the function to grief any recipient out of accepting, and off-chain indexers had no way to know an earlier transfer had been superseded.
- Add a new `TransferAlreadyPending` error and reject any new initiation while a pending transfer exists. Callers must explicitly `cancel_campaign_transfer` first — that path already emits a cancellation event that indexers can track.
- Update the existing reinitiation test to assert the new rejection and to verify the first recipient can still accept.

Closes #340

## Test plan
- [x] `cargo test --lib campaign_transfer` — all 6 transfer-flow tests pass
- [x] `cargo test --lib transfer -- --skip pagination_boundaries` — all 17 transfer-related tests across the suite pass
- [x] Manual: verified `MaybePendingCreator` derives `PartialEq` so the new `!= MaybePendingCreator::None` comparison is sound