### PR TITLE
fix: gate claim_revenue on funds_withdrawn (#341)

### DIFF
--- a/src/benchmark_test.rs
+++ b/src/benchmark_test.rs
@@ -89,6 +89,7 @@ fn test_claim_revenue_instruction_budget() {
     let id = client.create_campaign(&make_revenue_campaign(&env, creator.clone()));
     client.verify_campaign(&id);
     client.contribute(&id, &contributor1, &1_000);
+    client.withdraw_funds(&id);
     client.deposit_revenue(&id, &2_000);
 
     env.budget().reset_default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -782,7 +782,10 @@ impl ProofOfHeart {
     ///
     /// # Errors
     /// * `CampaignNotFound` - No campaign with the given ID.
-    /// * `ValidationFailed` - Campaign has no revenue sharing, or caller has no contribution.
+    /// * `ValidationFailed` - Campaign has no revenue sharing, caller has no
+    ///   contribution, or funds have not yet been withdrawn (revenue sharing only
+    ///   begins after the creator has withdrawn funds, locking in `amount_raised`
+    ///   as the share denominator).
     /// * `NoFundsToWithdraw` - Nothing claimable at this time.
     pub fn claim_revenue(env: Env, campaign_id: u32, contributor: Address) -> Result<(), Error> {
         contributor.require_auth();
@@ -792,6 +795,15 @@ impl ProofOfHeart {
             return Err(Error::CampaignNotActive);
         }
         require_revenue_sharing(&campaign, Error::ValidationFailed)?;
+
+        // Block claims until the creator has withdrawn funds. Until then,
+        // `amount_raised` (the share denominator) can still grow as new
+        // contributions arrive, which would let early claimers compute their
+        // share against a smaller denominator than late claimers and create a
+        // race condition.
+        if !campaign.funds_withdrawn {
+            return Err(Error::ValidationFailed);
+        }
 
         let contribution = get_contribution(&env, campaign_id, &contributor);
         if contribution == 0 {

--- a/src/storage_cleanup_test.rs
+++ b/src/storage_cleanup_test.rs
@@ -137,52 +137,8 @@ fn test_voting_keys_absent_after_cancel() {
     );
 }
 
-/// RevenueClaimed key is removed when contributor claims refund on a revenue-sharing campaign.
-#[test]
-fn test_revenue_claimed_key_removed_on_refund() {
-    let (env, _admin, creator, contributor1, _contributor2, _token, token_admin, client) =
-        setup_env();
-
-    token_admin.mint(&contributor1, &10_000);
-    token_admin.mint(&creator, &5_000);
-
-    let id = client.create_campaign(&make_params_local(creator.clone(), &env, 5_000, true));
-    client.verify_campaign(&id);
-    client.contribute(&id, &contributor1, &5_000);
-
-    // Deposit revenue so contributor can claim some
-    client.deposit_revenue(&id, &1_000);
-    client.claim_revenue(&id, &contributor1);
-
-    // RevenueClaimed key now exists
-    assert!(
-        has_persistent_key(
-            &env,
-            &client,
-            DataKey::RevenueClaimed(id, contributor1.clone())
-        ),
-        "RevenueClaimed key must exist after claim_revenue"
-    );
-
-    // Cancel and refund
-    client.cancel_campaign(&id);
-    client.claim_refund(&id, &contributor1);
-
-    // Both keys must be gone
-    assert!(
-        !has_persistent_key(
-            &env,
-            &client,
-            DataKey::Contribution(id, contributor1.clone())
-        ),
-        "Contribution key must be removed after refund"
-    );
-    assert!(
-        !has_persistent_key(
-            &env,
-            &client,
-            DataKey::RevenueClaimed(id, contributor1.clone())
-        ),
-        "RevenueClaimed key must be removed after refund"
-    );
-}
+// Issue #341: claim_revenue is gated on funds_withdrawn, and cancel is gated
+// on !funds_withdrawn, so the prior "claim → cancel → refund cleans
+// RevenueClaimed" path is no longer reachable. The defensive cleanup remains
+// in claim_refund; behavioural coverage of the new guard lives in
+// test::test_claim_revenue_blocked_before_funds_withdrawn.

--- a/src/test.rs
+++ b/src/test.rs
@@ -3034,16 +3034,21 @@ fn test_claim_refund_expired_campaign() {
     assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
 }
 
+// Issue #341: claim_revenue must be gated on funds_withdrawn. The prior version
+// of this test exercised a "claim before withdraw, then cancel, then refund"
+// flow which is now structurally impossible (cancel is blocked once funds are
+// withdrawn). We keep this slot as a regression test for the funds_withdrawn
+// guard.
 #[test]
-fn test_claim_refund_clears_existing_revenue_claimed_key() {
+fn test_claim_revenue_blocked_before_funds_withdrawn() {
     let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
     token_admin.mint(&contributor1, &5000);
     token_admin.mint(&creator, &10_000);
 
     let campaign_id = client.create_campaign(&CreateCampaignParams {
         creator: creator.clone(),
-        title: String::from_str(&env, "Refund Cleans Revenue Claim"),
-        description: String::from_str(&env, "Ensure RevenueClaimed key is removed"),
+        title: String::from_str(&env, "Claim Gated On Withdraw"),
+        description: String::from_str(&env, "Revenue claim must wait for funds_withdrawn"),
         funding_goal: 5000,
         duration_days: 30,
         category: Category::EducationalStartup,
@@ -3052,17 +3057,17 @@ fn test_claim_refund_clears_existing_revenue_claimed_key() {
         max_contribution_per_user: 0i128,
     });
     client.verify_campaign(&campaign_id);
-    client.contribute(&campaign_id, &contributor1, &1000);
+    client.contribute(&campaign_id, &contributor1, &5000);
     client.deposit_revenue(&campaign_id, &1000);
+
+    // Funds not yet withdrawn — claim must be rejected.
+    let res = client.try_claim_revenue(&campaign_id, &contributor1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    // After withdrawal, the same call succeeds.
+    client.withdraw_funds(&campaign_id);
     client.claim_revenue(&campaign_id, &contributor1);
-
-    let claimed_before_refund = client.get_revenue_claimed(&campaign_id, &contributor1);
-    assert!(claimed_before_refund > 0);
-
-    client.cancel_campaign(&campaign_id);
-    client.claim_refund(&campaign_id, &contributor1);
-
-    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
+    assert!(client.get_revenue_claimed(&campaign_id, &contributor1) > 0);
 }
 
 #[test]
@@ -4047,10 +4052,13 @@ fn test_claim_revenue_amount_raised_zero_guard() {
     client.verify_campaign(&campaign_id);
     client.contribute(&campaign_id, &contributor1, &500);
 
-    // Artificially zero out amount_raised while keeping the contribution in storage
+    // Artificially zero out amount_raised while keeping the contribution in storage.
+    // Also force funds_withdrawn=true so we bypass the funds_withdrawn guard and
+    // exercise the AmountRaisedIsZero guard specifically.
     env.as_contract(&client.address, || {
         let mut campaign = get_campaign(&env, campaign_id).unwrap();
         campaign.amount_raised = 0;
+        campaign.funds_withdrawn = true;
         set_campaign(&env, campaign_id, &campaign);
     });
 

--- a/src/tests/test_refund_edge.rs
+++ b/src/tests/test_refund_edge.rs
@@ -1,5 +1,5 @@
 use super::helpers::*;
-use crate::{Category, CreateCampaignParams, Error};
+use crate::{Category, Error};
 use soroban_sdk::String;
 
 #[test]
@@ -93,33 +93,7 @@ fn test_claim_refund_expired_campaign() {
     assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
 }
 
-#[test]
-fn test_claim_refund_clears_existing_revenue_claimed_key() {
-    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
-    token_admin.mint(&contributor1, &5000);
-    token_admin.mint(&creator, &10_000);
-
-    let campaign_id = client.create_campaign(&CreateCampaignParams {
-        creator: creator.clone(),
-        title: String::from_str(&env, "Refund Cleans Revenue Claim"),
-        description: String::from_str(&env, "Ensure RevenueClaimed key is removed"),
-        funding_goal: 5000,
-        duration_days: 30,
-        category: Category::EducationalStartup,
-        has_revenue_sharing: true,
-        revenue_share_percentage: 2000,
-        max_contribution_per_user: 0i128,
-    });
-    client.verify_campaign(&campaign_id);
-    client.contribute(&campaign_id, &contributor1, &1000);
-    client.deposit_revenue(&campaign_id, &1000);
-    client.claim_revenue(&campaign_id, &contributor1);
-
-    let claimed_before_refund = client.get_revenue_claimed(&campaign_id, &contributor1);
-    assert!(claimed_before_refund > 0);
-
-    client.cancel_campaign(&campaign_id);
-    client.claim_refund(&campaign_id, &contributor1);
-
-    assert_eq!(client.get_revenue_claimed(&campaign_id, &contributor1), 0);
-}
+// Issue #341: claim_revenue is gated on funds_withdrawn. The prior "claim
+// then cancel then refund" flow this test exercised is now structurally
+// impossible (cancel is blocked once funds are withdrawn). Covered by
+// test::test_claim_revenue_blocked_before_funds_withdrawn.


### PR DESCRIPTION
## Summary
- `claim_revenue` had no `funds_withdrawn` check, so if a creator deposited revenue while the campaign was still active any contributor with a non-zero balance could immediately claim a share. Because `amount_raised` (the share denominator) keeps growing while contributions arrive, early claimers received a larger proportional payout than late claimers — a race condition on top of an out-of-lifecycle extraction.
- Reject `claim_revenue` with `ValidationFailed` when `!campaign.funds_withdrawn`. Withdrawal locks in `amount_raised` and also blocks subsequent cancellation, so all live claims now run against the same finalised denominator.
- Test updates: benchmark path now calls `withdraw_funds` before `claim_revenue`; the `AmountRaisedIsZero` guard test also forces `funds_withdrawn = true` artificially; the three "claim → cancel → refund cleans RevenueClaimed" tests covered a flow that is now structurally impossible (cancel is blocked once funds are withdrawn), so one was rewritten as a regression test for the new guard and the other two reduced to pointer comments.

Closes #341

## Test plan
- [x] `cargo test --lib revenue` — 44/44 pass
- [x] `cargo test --lib claim_revenue` — 5/5 pass, including the new `test_claim_revenue_blocked_before_funds_withdrawn`
- [x] `cargo test --lib refund` — 24/24 pass
- [x] Full suite minus unrelated pre-existing failures — 290 pass