### PR TITLE
fix: cap purge_voting_state batch and defer aggregate clear (#342)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1820,11 +1820,16 @@ impl ProofOfHeart {
         Ok(())
     }
 
-    /// Removes voting-related storage keys for a terminal campaign.
+    /// Removes voting-related storage keys for a terminal campaign in batches.
     ///
-    /// Clears `ApproveVotes`, `RejectVotes`, `ApproveWeight`, `RejectWeight`, and
-    /// `HasVoted` entries for each address in `voters`. Must only be called after
-    /// the campaign has reached a terminal state (`funds_withdrawn` or `is_cancelled`).
+    /// Always clears the `HasVoted` entry for each address in `voters`. The
+    /// aggregate vote keys (`ApproveVotes`, `RejectVotes`, `ApproveWeight`,
+    /// `RejectWeight`) and the `voting_state_purged` event are only cleared
+    /// when `finalize_aggregate == true`, so the admin can split a large voter
+    /// set across multiple calls and only finalize after the last batch.
+    ///
+    /// Must only be called after the campaign has reached a terminal state
+    /// (`funds_withdrawn` or `is_cancelled`).
     ///
     /// # Authorization
     /// Requires admin authorization.
@@ -1832,11 +1837,13 @@ impl ProofOfHeart {
     /// # Errors
     /// * `CampaignNotFound` - No campaign with the given ID.
     /// * `NotAuthorized` - Caller is not the admin.
-    /// * `ValidationFailed` - Campaign is not yet in a terminal state.
+    /// * `ValidationFailed` - Campaign is not yet in a terminal state, the
+    ///   voter list is empty, or the voter list exceeds `MAX_VOTERS_PER_CALL`.
     pub fn purge_voting_state(
         env: Env,
         campaign_id: u32,
         voters: soroban_sdk::Vec<Address>,
+        finalize_aggregate: bool,
     ) -> Result<(), Error> {
         let admin = get_admin(&env);
         assert_admin(&env, &admin)?;
@@ -1852,19 +1859,28 @@ impl ProofOfHeart {
             return Err(Error::ValidationFailed);
         }
 
-        // Cap batch size to prevent compute budget exhaustion
-        const MAX_PURGE_BATCH: u32 = 100;
-        if voters.len() > MAX_PURGE_BATCH {
+        // Cap batch size to keep the call below the Soroban instruction limit
+        // and give callers a predictable batching contract. Aligned with
+        // verify_campaigns::MAX_BATCH_SIZE.
+        const MAX_VOTERS_PER_CALL: u32 = 50;
+        if voters.len() > MAX_VOTERS_PER_CALL {
             return Err(Error::ValidationFailed);
         }
 
         for voter in voters.iter() {
             remove_has_voted(&env, campaign_id, &voter);
         }
-        remove_voting_state(&env, campaign_id);
 
-        env.events()
-            .publish(("voting_state_purged", campaign_id), ());
+        // Only clear aggregate vote counts and emit the purged event on the
+        // final batch. Doing it on every call would orphan any HasVoted entries
+        // not yet supplied by the admin and emit a misleading "purged" event
+        // partway through cleanup.
+        if finalize_aggregate {
+            remove_voting_state(&env, campaign_id);
+            env.events()
+                .publish(("voting_state_purged", campaign_id), ());
+        }
+
         Ok(())
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -11,6 +11,7 @@ mod test_duration_cap;
 mod test_fee_override;
 mod test_init;
 mod test_listing;
+mod test_purge_voting;
 mod test_refund;
 mod test_refund_edge;
 mod test_revenue;

--- a/src/tests/test_purge_voting.rs
+++ b/src/tests/test_purge_voting.rs
@@ -1,0 +1,126 @@
+// Tests for issue #342: purge_voting_state batch cap and finalize semantics.
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::{testutils::Address as _, Address, String, Vec};
+
+fn make_voters(env: &soroban_sdk::Env, count: u32) -> Vec<Address> {
+    let mut voters = Vec::new(env);
+    for _ in 0..count {
+        voters.push_back(Address::generate(env));
+    }
+    voters
+}
+
+/// Set up a cancelled campaign with `voter_count` token-holding voters that have
+/// each cast an approve vote. Returns the campaign id and the voters.
+fn cancelled_campaign_with_voters(
+    env: &soroban_sdk::Env,
+    client: &ProofOfHeartClient<'_>,
+    creator: &Address,
+    token_admin: &TokenAdminClient<'_>,
+    voter_count: u32,
+) -> (u32, Vec<Address>) {
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(env, "Purge Voting Test"),
+        String::from_str(env, "Voting state purge regression"),
+        1_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let voters = make_voters(env, voter_count);
+    for voter in voters.iter() {
+        token_admin.mint(&voter, &100);
+        client.vote_on_campaign(&campaign_id, &voter, &true);
+    }
+
+    client.cancel_campaign(&campaign_id);
+    (campaign_id, voters)
+}
+
+#[test]
+fn test_purge_voting_state_rejects_oversized_batch() {
+    let (env, _admin, creator, _c1, _c2, _token, token_admin, client) = setup_env();
+    let (campaign_id, _) = cancelled_campaign_with_voters(&env, &client, &creator, &token_admin, 1);
+
+    // 51 voters exceeds the MAX_VOTERS_PER_CALL = 50 cap.
+    let oversized = make_voters(&env, 51);
+    let res = client.try_purge_voting_state(&campaign_id, &oversized, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_purge_voting_state_rejects_empty_batch() {
+    let (env, _admin, creator, _c1, _c2, _token, token_admin, client) = setup_env();
+    let (campaign_id, _) = cancelled_campaign_with_voters(&env, &client, &creator, &token_admin, 1);
+
+    let empty: Vec<Address> = Vec::new(&env);
+    let res = client.try_purge_voting_state(&campaign_id, &empty, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_purge_voting_state_non_finalize_keeps_aggregate() {
+    let (env, _admin, creator, _c1, _c2, _token, token_admin, client) = setup_env();
+    let (campaign_id, voters) =
+        cancelled_campaign_with_voters(&env, &client, &creator, &token_admin, 3);
+
+    let mut batch: Vec<Address> = Vec::new(&env);
+    batch.push_back(voters.get(0).unwrap());
+
+    // Non-final batch — HasVoted for the supplied voter is cleared but the
+    // aggregate vote counts remain so the cleanup can continue across calls.
+    client.purge_voting_state(&campaign_id, &batch, &false);
+
+    assert!(!client.has_voted(&campaign_id, &voters.get(0).unwrap()));
+    assert!(client.has_voted(&campaign_id, &voters.get(1).unwrap()));
+    assert_eq!(client.get_approve_votes(&campaign_id), 3);
+}
+
+#[test]
+fn test_purge_voting_state_finalize_clears_aggregate() {
+    let (env, _admin, creator, _c1, _c2, _token, token_admin, client) = setup_env();
+    let (campaign_id, voters) =
+        cancelled_campaign_with_voters(&env, &client, &creator, &token_admin, 2);
+
+    client.purge_voting_state(&campaign_id, &voters, &true);
+
+    for voter in voters.iter() {
+        assert!(!client.has_voted(&campaign_id, &voter));
+    }
+    assert_eq!(client.get_approve_votes(&campaign_id), 0);
+    assert_eq!(client.get_reject_votes(&campaign_id), 0);
+}
+
+#[test]
+fn test_purge_voting_state_split_batches_then_finalize() {
+    let (env, _admin, creator, _c1, _c2, _token, token_admin, client) = setup_env();
+    let (campaign_id, voters) =
+        cancelled_campaign_with_voters(&env, &client, &creator, &token_admin, 4);
+
+    let mut first: Vec<Address> = Vec::new(&env);
+    first.push_back(voters.get(0).unwrap());
+    first.push_back(voters.get(1).unwrap());
+
+    let mut second: Vec<Address> = Vec::new(&env);
+    second.push_back(voters.get(2).unwrap());
+    second.push_back(voters.get(3).unwrap());
+
+    client.purge_voting_state(&campaign_id, &first, &false);
+    assert_eq!(
+        client.get_approve_votes(&campaign_id),
+        4,
+        "aggregate must survive the non-final batch"
+    );
+
+    client.purge_voting_state(&campaign_id, &second, &true);
+
+    for voter in voters.iter() {
+        assert!(!client.has_voted(&campaign_id, &voter));
+    }
+    assert_eq!(client.get_approve_votes(&campaign_id), 0);
+}


### PR DESCRIPTION
## Summary
- `purge_voting_state` had a 100-voter cap and always cleared the aggregate vote keys (`ApproveVotes`, `RejectVotes`, `ApproveWeight`, `RejectWeight`) on every call. An admin facing more than ~100 voters could not split cleanup across calls without leaking state: the first call would wipe the aggregates while leaving the remaining `HasVoted` entries orphaned. The 100 cap also diverged from `verify_campaigns::MAX_BATCH_SIZE` (50), so callers had no single batching convention.
- Lower the cap to 50 (renamed `MAX_PURGE_BATCH` → `MAX_VOTERS_PER_CALL`) and add a `finalize_aggregate: bool` parameter. The `HasVoted` loop runs on every call, but the aggregate clear and the `voting_state_purged` event only fire when the admin signals the batch is the last one. The signature change is safe — there were no in-tree callers.
- Add `tests/test_purge_voting.rs` with five focused tests: 50-voter cap, empty-voter guard, `finalize=false` preserves aggregates, `finalize=true` clears them, and split-batch flow that ends with all state gone.

Closes #342

## Test plan
- [x] `cargo test --lib test_purge_voting` — 5/5 pass
- [x] `cargo test --lib voting` — 47/47 pass (no regressions in existing voting paths)
- [x] Full suite minus unrelated pre-existing failures — 297 pass