### PR TITLE
fix: reject out-of-range platform_fee in init (#343)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ impl ProofOfHeart {
     /// * `admin` - The global admin address.
     /// * `token` - The required token for contributions and revenue.
     /// * `platform_fee` - The fee percentage taken from funds (max 1000 = 10%).
+    ///   Values above the cap are rejected rather than silently clamped, so the
+    ///   admin always knows the stored fee matches the intended fee.
     ///
     /// # Authorization
     /// Requires `admin.require_auth()`.
@@ -140,6 +142,13 @@ impl ProofOfHeart {
             return Err(Error::AlreadyInitialized);
         }
         admin.require_auth();
+
+        // Validate the fee up front so the caller gets a clear error instead of
+        // a silently-clamped value. Matches the validation contract in
+        // `update_platform_fee` and `set_campaign_fee_override`.
+        if platform_fee > PLATFORM_FEE_MAX_BPS {
+            return Err(Error::ValidationFailed);
+        }
 
         // Validate that the address is a real SEP-41 token contract by probing
         // its decimals() function. try_invoke_contract returns Err when the call
@@ -158,12 +167,7 @@ impl ProofOfHeart {
         set_token(&env, &token);
         set_initialized(&env);
 
-        let valid_fee = if platform_fee > PLATFORM_FEE_MAX_BPS {
-            PLATFORM_FEE_MAX_BPS
-        } else {
-            platform_fee
-        };
-        set_platform_fee(&env, valid_fee);
+        set_platform_fee(&env, platform_fee);
         set_campaign_count(&env, 0);
         set_total_raised_global(&env, 0);
         set_version(&env, CONTRACT_VERSION);
@@ -177,7 +181,7 @@ impl ProofOfHeart {
             ("initialized", admin.clone()),
             (
                 token.clone(),
-                valid_fee,
+                platform_fee,
                 voting::DEFAULT_MIN_VOTES_QUORUM,
                 voting::DEFAULT_APPROVAL_THRESHOLD_BPS,
                 CONTRACT_VERSION,

--- a/src/test.rs
+++ b/src/test.rs
@@ -112,12 +112,15 @@ fn test_platform_fee_cap_enforcement() {
     let contract_id = env.register_contract(None, ProofOfHeart);
     let client = ProofOfHeartClient::new(&env, &contract_id);
 
-    // Initialize with fee > 1000 (5000 = 50%), should be capped to 1000 (10%)
-    client.init(&admin, &token_address, &5000);
+    // Issue #343: init rejects fees above the cap rather than silently clamping.
+    let res = client.try_init(&admin, &token_address, &5000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    // Re-init with the maximum allowed fee and verify it applies end-to-end.
+    client.init(&admin, &token_address, &1000);
     env.as_contract(&client.address, || set_min_campaign_funding_goal(&env, 1));
     assert_eq!(client.get_platform_fee(), 1000);
 
-    // Verify withdrawal uses capped fee (10%), not original input (50%)
     token_admin.mint(&contributor, &2000);
 
     let title = String::from_str(&env, "Fee Cap Test");
@@ -1055,8 +1058,9 @@ fn test_update_platform_fee() {
     assert_eq!(data_vec.get(0).unwrap(), 300);
     assert_eq!(data_vec.get(1).unwrap(), 500);
 
+    // Issue #343: fees above the cap are rejected, not silently clamped.
     let result = client.try_update_platform_fee(&5000);
-    assert!(result.is_ok(), "Fee update should succeed even when capped");
+    assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
 #[test]

--- a/src/tests/test_admin.rs
+++ b/src/tests/test_admin.rs
@@ -19,8 +19,9 @@ fn test_update_platform_fee() {
     assert_eq!(data_vec.get(0).unwrap(), 300);
     assert_eq!(data_vec.get(1).unwrap(), 500);
 
+    // Issue #343: fees above the cap are rejected, not silently clamped.
     let result = client.try_update_platform_fee(&5000);
-    assert!(result.is_ok());
+    assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
 #[test]

--- a/src/tests/test_init.rs
+++ b/src/tests/test_init.rs
@@ -25,7 +25,12 @@ fn test_platform_fee_cap_enforcement() {
     let contract_id = env.register_contract(None, crate::ProofOfHeart);
     let client = crate::ProofOfHeartClient::new(&env, &contract_id);
 
-    client.init(&admin, &token_address, &5000);
+    // Issue #343: init rejects fees above the cap rather than silently clamping.
+    let res = client.try_init(&admin, &token_address, &5000);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    // Re-init with the maximum allowed fee and verify it applies end-to-end.
+    client.init(&admin, &token_address, &1000);
     env.as_contract(&client.address, || set_min_campaign_funding_goal(&env, 1));
     assert_eq!(client.get_platform_fee(), 1000);
 


### PR DESCRIPTION
## Summary
- `init` silently clamped `platform_fee` to `PLATFORM_FEE_MAX_BPS` when the admin passed a higher value — the same anti-pattern that #336 already removed from `update_platform_fee` and `set_campaign_fee_override`. A misconfigured deploy would record the clamped fee in the `initialized` event with no signal that the requested value was ignored.
- Validate `platform_fee` up front and return `Error::ValidationFailed` when it exceeds the cap. Drop the `valid_fee` rebinding so the stored value and the emitted event always equal the input, matching the contract every other fee path now enforces.
- Test updates: the two `test_platform_fee_cap_enforcement` tests now assert the oversized init is rejected, then re-init at the cap to keep the end-to-end fee assertions intact. The two `test_update_platform_fee` tests were still asserting silent-clamp success on `update_platform_fee(5000)` and have been failing on `main` since the function was fixed in #336 — both are now updated to assert `ValidationFailed`, clearing those pre-existing regressions.

Closes #343

## Test plan
- [x] `cargo test --lib platform_fee` — 6/6 pass (including the two previously-failing `test_update_platform_fee` cases)
- [x] Full suite minus unrelated pre-existing failures — 294 pass