### PR TITLE
Fix resume_campaign no-op behavior and campaign_updated metadata payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `claim_creator_revenue` returns `ValidationFailed` when `revenue_share_percentage > 10000` instead of producing negative math or panicking (#167).
 - `initiate_campaign_transfer` now rejects cancelled or withdrawn campaigns, keeping ownership transfers off terminal campaigns (#323).
 - `resume_campaign` now returns `ValidationFailed` when no pause is active, preventing spurious state writes and `campaign_resumed` events (#348).
+- `update_campaign` now emits both the updated title and description in `campaign_updated`, allowing full metadata indexing without extra reads (#349).
 
 ### Refactored
 - Extracted `assert_admin(env, caller)` helper; used in `pause`, `unpause`, and `set_voting_params` to provide a single source of truth for admin authorization (#224).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `update_campaign_description` now blocks edits once `amount_raised > 0`, preventing bait-and-switch after contributions (#166).
 - `claim_creator_revenue` returns `ValidationFailed` when `revenue_share_percentage > 10000` instead of producing negative math or panicking (#167).
 - `initiate_campaign_transfer` now rejects cancelled or withdrawn campaigns, keeping ownership transfers off terminal campaigns (#323).
+- `resume_campaign` now returns `ValidationFailed` when no pause is active, preventing spurious state writes and `campaign_resumed` events (#348).
 
 ### Refactored
 - Extracted `assert_admin(env, caller)` helper; used in `pause`, `unpause`, and `set_voting_params` to provide a single source of truth for admin authorization (#224).

--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -32,7 +32,7 @@ Emitted when a new campaign is created.
 Emitted when campaign title and description are updated (before any contributions).
 
 - **Topics**: `["campaign_updated", campaign_id]`
-- **Data**: `new_title`
+- **Data**: `(new_title, new_description)`
 - **Emitted By**: `update_campaign()`
 
 #### `campaign_description_updated`

--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -186,6 +186,14 @@ Emitted when the contract is unpaused by the admin.
 - **Data**: `()`
 - **Emitted By**: `unpause()`
 
+#### `campaign_resumed`
+Emitted when an authorized caller resumes an actively paused campaign context.
+
+- **Topics**: `["campaign_resumed", campaign_id, caller_address]`
+- **Data**: `()`
+- **Emitted By**: `resume_campaign()`
+- **Behavior**: Not emitted when the contract is already unpaused; that call now returns `ValidationFailed`.
+
 #### `fee_updated`
 Emitted when the platform fee is updated.
 

--- a/src/issues_test.rs
+++ b/src/issues_test.rs
@@ -200,3 +200,18 @@ fn test_get_campaigns_by_category_small_limit_respected() {
     let result = client.get_campaigns_by_category(&Category::Learner, &0u32, &5u32);
     assert_eq!(result.len(), 5);
 }
+
+// ── #348 resume_campaign spurious events/state writes ─────────────────────────
+
+#[test]
+fn test_resume_campaign_rejects_when_contract_not_paused() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let campaign_id = client.create_campaign(&make_campaign_params_simple(&env, &creator));
+
+    let events_before = env.events().all().len();
+    let result = client.try_resume_campaign(&campaign_id, &creator);
+    let events_after = env.events().all().len();
+
+    assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
+    assert_eq!(events_before, events_after);
+}

--- a/src/issues_test.rs
+++ b/src/issues_test.rs
@@ -215,3 +215,17 @@ fn test_resume_campaign_rejects_when_contract_not_paused() {
     assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
     assert_eq!(events_before, events_after);
 }
+
+#[test]
+fn test_resume_campaign_clears_auto_pause_when_active() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+    let campaign_id = client.create_campaign(&make_campaign_params_simple(&env, &creator));
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&DataKey::AutoPaused, &true);
+    });
+
+    assert!(client.is_paused());
+    client.resume_campaign(&campaign_id, &creator);
+    assert!(!client.is_paused());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2085,6 +2085,10 @@ impl ProofOfHeart {
             return Err(Error::NotAuthorized);
         }
 
+        if !Self::is_paused(env.clone()) {
+            return Err(Error::ValidationFailed);
+        }
+
         bump_instance_ttl(&env);
         env.storage().instance().set(&DataKey::AutoPaused, &false);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,13 +678,14 @@ impl ProofOfHeart {
         }
 
         bump_instance_ttl(&env);
+        let event_description = description.clone();
         campaign.title = title.clone();
         campaign.description = description;
 
         set_campaign(&env, campaign_id, &campaign);
 
         env.events()
-            .publish(("campaign_updated", campaign_id), title);
+            .publish(("campaign_updated", campaign_id), (title, event_description));
 
         Ok(())
     }

--- a/src/tests/test_campaign_update.rs
+++ b/src/tests/test_campaign_update.rs
@@ -27,6 +27,34 @@ fn test_update_campaign_allows_verified_campaign_before_contributions() {
 }
 
 #[test]
+fn test_update_campaign_emits_title_and_description() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        String::from_str(&env, "Original Description"),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    let new_title = String::from_str(&env, "Updated Title");
+    let new_desc = String::from_str(&env, "Updated Description");
+    client.update_campaign(&campaign_id, &new_title, &new_desc);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+
+    assert_eq!(payload.0, new_title);
+    assert_eq!(payload.1, new_desc);
+}
+
+#[test]
 fn test_update_campaign_allows_verified_campaign_with_votes_before_contributions() {
     let (env, _admin, creator, contributor1, contributor2, _, token_admin, client) = setup_env();
     let voter3 = Address::generate(&env);

--- a/src/tests/test_campaign_update.rs
+++ b/src/tests/test_campaign_update.rs
@@ -55,6 +55,40 @@ fn test_update_campaign_emits_title_and_description() {
 }
 
 #[test]
+fn test_update_campaign_event_tracks_latest_description() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        String::from_str(&env, "Original Description"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.update_campaign(
+        &campaign_id,
+        &String::from_str(&env, "Title V2"),
+        &String::from_str(&env, "Description V2"),
+    );
+    client.update_campaign(
+        &campaign_id,
+        &String::from_str(&env, "Title V3"),
+        &String::from_str(&env, "Description V3"),
+    );
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(payload.0, String::from_str(&env, "Title V3"));
+    assert_eq!(payload.1, String::from_str(&env, "Description V3"));
+}
+
+#[test]
 fn test_update_campaign_allows_verified_campaign_with_votes_before_contributions() {
     let (env, _admin, creator, contributor1, contributor2, _, token_admin, client) = setup_env();
     let voter3 = Address::generate(&env);


### PR DESCRIPTION
## Summary
- return `ValidationFailed` from `resume_campaign` when no pause is active, preventing no-op state writes and spurious `campaign_resumed` events
- update `campaign_updated` to emit `(title, description)` so indexers receive complete metadata updates directly from events
- add focused regression coverage plus changelog/event-payload documentation updates for both fixes

## Verification
- Skipped tests (not run by default per request)

Closes #348
Closes #349

Made with [Cursor](https://cursor.com)