### PR TITLE
Fix #330 and #331: event schema and deadline cap guard

### DIFF
--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -212,7 +212,7 @@ Emitted when admin privileges are transferred.
 ### Pattern 1: Track All Campaigns
 ```
 Listen for: "campaign_created" events
-Index: Map campaign_id -> (creator, title, timestamp)
+Index: Map campaign_id -> (creator, title, category_u32, timestamp)
 ```
 
 ### Pattern 2: Track Campaign Contributions

--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -27,6 +27,7 @@ Emitted when a new campaign is created.
 - **Data**: `(campaign_title, category_u32)`
 - **Emitted By**: `create_campaign()`
 - **Indexing Tip**: Track all campaigns by creator or scan campaign IDs chronologically.
+- **Breaking Change Note**: Consumers expecting a plain title payload must decode `(String, u32)` instead.
 
 #### `campaign_updated`
 Emitted when campaign title and description are updated (before any contributions).

--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -24,7 +24,7 @@ Emitted when the contract is initialized.
 Emitted when a new campaign is created.
 
 - **Topics**: `["campaign_created", campaign_id, creator_address]`
-- **Data**: `campaign_title`
+- **Data**: `(campaign_title, category_u32)`
 - **Emitted By**: `create_campaign()`
 - **Indexing Tip**: Track all campaigns by creator or scan campaign IDs chronologically.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1410,6 +1410,8 @@ impl ProofOfHeart {
     /// - Extension must be requested before the original deadline.
     /// - The total duration (original + extension) must not exceed the
     ///   category's duration cap (Option B).
+    /// - Campaigns missing a persisted start time are rejected to avoid
+    ///   silently bypassing category duration caps.
     ///
     /// # Authorization
     /// Requires `campaign.creator.require_auth()`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1398,6 +1398,10 @@ impl ProofOfHeart {
         Ok(())
     }
 
+    fn campaign_start_time_or_error(env: &Env, campaign_id: u32) -> Result<u64, Error> {
+        get_campaign_start_time(env, campaign_id).ok_or(Error::InvalidDuration)
+    }
+
     /// Extends the deadline of a campaign by `additional_days` (creator only).
     ///
     /// Rules:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ impl ProofOfHeart {
         set_creator_campaign_count(&env, &creator, creator_count + 1);
 
         env.events()
-            .publish(("campaign_created", count, creator), title);
+            .publish(("campaign_created", count, creator), (title, category as u32));
 
         Ok(count)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1438,18 +1438,17 @@ impl ProofOfHeart {
             .ok_or(Error::Overflow)?;
 
         // Enforce per-category duration cap (Option B).
-        if let Some(start_time) = get_campaign_start_time(&env, campaign_id) {
-            let category_cap = get_category_duration_cap(&env, campaign.category)
-                .unwrap_or(CAMPAIGN_DURATION_MAX_DAYS);
+        let start_time = Self::campaign_start_time_or_error(&env, campaign_id)?;
+        let category_cap =
+            get_category_duration_cap(&env, campaign.category).unwrap_or(CAMPAIGN_DURATION_MAX_DAYS);
 
-            let total_duration_seconds = new_deadline
-                .checked_sub(start_time)
-                .ok_or(Error::Overflow)?;
-            let total_duration_days = total_duration_seconds / 86400;
+        let total_duration_seconds = new_deadline
+            .checked_sub(start_time)
+            .ok_or(Error::Overflow)?;
+        let total_duration_days = total_duration_seconds / 86400;
 
-            if total_duration_days > category_cap {
-                return Err(Error::InvalidDuration);
-            }
+        if total_duration_days > category_cap {
+            return Err(Error::InvalidDuration);
         }
 
         bump_instance_ttl(&env);

--- a/src/lifecycle_events_test.rs
+++ b/src/lifecycle_events_test.rs
@@ -167,3 +167,42 @@ fn test_campaign_cancelled_event_includes_creator_and_amount() {
     let amount_raised: i128 = soroban_sdk::FromVal::from_val(&env, &last_event.2);
     assert_eq!(amount_raised, 500);
 }
+
+#[test]
+fn test_campaign_created_event_includes_category() {
+    let (env, _admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    let expected_title = String::from_str(&env, "Created Event Category");
+    let expected_category = Category::Learner;
+
+    client.create_campaign(&CreateCampaignParams {
+        creator,
+        title: expected_title.clone(),
+        description: String::from_str(&env, "Schema coverage"),
+        funding_goal: 1_000,
+        duration_days: 30,
+        category: expected_category,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    });
+
+    let events = env.events().all();
+    let created_event = events
+        .iter()
+        .rev()
+        .find(|(_, topics, _)| {
+            topics
+                .get(0)
+                .and_then(|v| String::try_from_val(&env, &v).ok())
+                .map(|topic| topic == String::from_str(&env, "campaign_created"))
+                .unwrap_or(false)
+        })
+        .expect("campaign_created event must exist");
+
+    let (title, category_discriminant): (String, u32) =
+        soroban_sdk::FromVal::from_val(&env, &created_event.2);
+    assert_eq!(title, expected_title);
+    assert_eq!(category_discriminant, expected_category as u32);
+}

--- a/src/tests/test_deadline_ext.rs
+++ b/src/tests/test_deadline_ext.rs
@@ -146,8 +146,8 @@ fn test_extend_deadline_beyond_category_cap_rejected() {
 }
 
 #[test]
-fn test_extend_deadline_without_start_time_fallback() {
-    // This tests the fallback for campaigns created before start_time tracking was added
+fn test_extend_deadline_without_start_time_rejected() {
+    // Legacy campaigns without start_time cannot bypass category duration checks.
     let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
 
     let id = client.create_campaign(&make_params(
@@ -170,7 +170,7 @@ fn test_extend_deadline_without_start_time_fallback() {
 
     client.set_category_duration_cap(&admin, &Category::Learner, &30);
 
-    // Should succeed because start_time is missing (fallback to Option A behavior)
+    // Missing start_time now rejects the extension to avoid cap bypass.
     let res = client.try_extend_campaign_deadline(&id, &30);
-    assert!(res.is_ok());
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
 }

--- a/src/tests/test_deadline_ext.rs
+++ b/src/tests/test_deadline_ext.rs
@@ -174,3 +174,34 @@ fn test_extend_deadline_without_start_time_rejected() {
     let res = client.try_extend_campaign_deadline(&id, &30);
     assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
 }
+
+#[test]
+fn test_extend_deadline_without_start_time_keeps_deadline_unchanged() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Old Campaign Immutable"),
+        String::from_str(&env, "Legacy no-start-time"),
+        1000,
+        20,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let original_deadline = client.get_campaign(&id).deadline;
+
+    env.as_contract(&client.address, || {
+        let key = crate::storage::DataKey::CampaignStartTime(id);
+        env.storage().persistent().remove(&key);
+    });
+
+    client.set_category_duration_cap(&admin, &Category::Learner, &25);
+
+    let res = client.try_extend_campaign_deadline(&id, &5);
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidDuration);
+    assert_eq!(client.get_campaign(&id).deadline, original_deadline);
+    assert!(!client.get_campaign(&id).deadline_extended);
+}


### PR DESCRIPTION
## Summary
- Include `category` in `campaign_created` event data as `(title, category_u32)` so indexers can categorize without extra state fetches.
- Update event payload documentation and indexing guidance to reflect the new `campaign_created` schema, including migration guidance for consumers.
- Enforce duration-cap checks in `extend_campaign_deadline` even for legacy campaigns by rejecting extensions when `start_time` is missing, and add regression tests for missing-start-time rejection/state safety.

## Verification
- Tests not run (per instruction to avoid running by default).
- Verified author/committer identity via `git log --format` for new commits: `fortezzalaboratory <fortezzalabs@gmail.com>`.

Closes #330
Closes #331

Made with [Cursor](https://cursor.com)