### PR TITLE
Fixed bugs in 4 GitHub issues (#376, #378, #379, #380) across voting.…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,9 @@ impl ProofOfHeart {
     /// Cancels a campaign. Can only be performed by the creator while the campaign is still active.
     ///
     /// If revenue has been deposited into the campaign's pool, the entire pool is returned to the
-    /// creator and the pool is cleared to prevent orphaned funds.
+    /// creator and the pool is cleared to prevent orphaned funds. The aggregate voting keys
+    /// (`ApproveVotes`, `RejectVotes`, `ApproveWeight`, `RejectWeight`) are purged immediately.
+    /// Per-voter `HasVoted` entries require a separate admin call to `purge_voting_state`.
     ///
     /// # Errors
     /// * `CampaignNotFound` - Campaign ID doesn't exist.
@@ -630,6 +632,7 @@ impl ProofOfHeart {
         campaign.is_cancelled = true;
         campaign.is_active = false;
         set_campaign(&env, campaign_id, &campaign);
+        remove_voting_state(&env, campaign_id);
         decrement_active_campaign_count(&env);
         increment_cancelled_campaign_count(&env);
 
@@ -1077,24 +1080,24 @@ impl ProofOfHeart {
 
     /// Bulk verify multiple campaigns. Can only be performed by the admin.
     ///
-    /// Caps the batch at 50 IDs for fee predictability.
-    /// Returns partial success semantics: verifies as many as possible and collects
-    /// errors for those that failed.
+    /// Caps the batch at 50 IDs for fee predictability. Returns `Ok(n)` only when all
+    /// campaigns in the batch are verified successfully. Returns `Err(first_error)` as
+    /// soon as any campaign fails, so callers can distinguish full success from partial
+    /// failure with a standard `Ok`/`Err` match.
     ///
     /// # Arguments
     /// * `campaign_ids` - List of campaign IDs to verify.
     ///
     /// # Returns
-    /// A tuple of (verified_count, first_error) where:
-    /// - `verified_count` is the number of campaigns successfully verified
-    /// - `first_error` is the first error encountered (if any)
+    /// `Ok(verified_count)` if every campaign verified successfully; `Err(e)` with the
+    /// first error encountered if any campaign failed.
     ///
     /// # Authorization
     /// Requires `admin.require_auth()`.
     pub fn verify_campaigns(
         env: Env,
         campaign_ids: soroban_sdk::Vec<u32>,
-    ) -> Result<(u32, Option<Error>), Error> {
+    ) -> Result<u32, Error> {
         let admin = get_admin(&env);
         assert_admin(&env, &admin)?;
         Self::require_not_paused(&env)?;
@@ -1131,7 +1134,11 @@ impl ProofOfHeart {
             (verified_count, campaign_ids.len()),
         );
 
-        Ok((verified_count, first_error))
+        if let Some(err) = first_error {
+            Err(err)
+        } else {
+            Ok(verified_count)
+        }
     }
 
     /// Checks if a campaign meets community verification thresholds and marks it verified.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -703,7 +703,7 @@ pub fn remove_personal_cap(env: &Env, campaign_id: u32, contributor: &Address) {
 /// Returns (ledger_sequence, contribution_count) for the block tracking.
 pub fn get_block_contribution_count(env: &Env) -> (u32, u32) {
     env.storage()
-        .temporary()
+        .instance()
         .get(&DataKey::BlockContributionCount)
         .unwrap_or((0, 0))
 }
@@ -711,14 +711,14 @@ pub fn get_block_contribution_count(env: &Env) -> (u32, u32) {
 /// Stores (ledger_sequence, contribution_count) for the block tracking.
 pub fn set_block_contribution_count(env: &Env, sequence: u32, count: u32) {
     env.storage()
-        .temporary()
+        .instance()
         .set(&DataKey::BlockContributionCount, &(sequence, count));
 }
 
 /// Returns (ledger_sequence, contribution_count) for a specific campaign.
 pub fn get_campaign_block_contribution_count(env: &Env, campaign_id: u32) -> (u32, u32) {
     env.storage()
-        .temporary()
+        .instance()
         .get(&DataKey::BlockCampaignContributionCount(campaign_id))
         .unwrap_or((0, 0))
 }
@@ -730,7 +730,7 @@ pub fn set_campaign_block_contribution_count(
     sequence: u32,
     count: u32,
 ) {
-    env.storage().temporary().set(
+    env.storage().instance().set(
         &DataKey::BlockCampaignContributionCount(campaign_id),
         &(sequence, count),
     );

--- a/src/storage_cleanup_test.rs
+++ b/src/storage_cleanup_test.rs
@@ -2,7 +2,7 @@
 // Probes storage after terminal actions to assert absence of orphan entries.
 use super::*;
 use crate::test::setup_env;
-use soroban_sdk::{testutils::Ledger, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String};
 
 fn make_params_local(
     creator: Address,
@@ -134,6 +134,45 @@ fn test_voting_keys_absent_after_cancel() {
     assert!(
         !has_persistent_key(&env, &client, DataKey::RejectVotes(id)),
         "RejectVotes must not exist"
+    );
+}
+
+/// Issue #380: after cancel_campaign, aggregate voting keys are purged even when votes were cast.
+#[test]
+fn test_voting_keys_purged_after_cancel_with_prior_votes() {
+    let (env, _admin, creator, _contributor1, _contributor2, _token, token_admin, client) =
+        setup_env();
+
+    let voter = Address::generate(&env);
+    token_admin.mint(&voter, &500);
+
+    let id = client.create_campaign(&make_params_local(creator.clone(), &env, 10_000, false));
+
+    // Cast a vote so the aggregate storage keys are written
+    client.vote_on_campaign(&id, &voter, &true);
+
+    assert!(
+        has_persistent_key(&env, &client, DataKey::ApproveVotes(id)),
+        "ApproveVotes must exist before cancel"
+    );
+
+    client.cancel_campaign(&id);
+
+    assert!(
+        !has_persistent_key(&env, &client, DataKey::ApproveVotes(id)),
+        "ApproveVotes must be purged after cancel"
+    );
+    assert!(
+        !has_persistent_key(&env, &client, DataKey::RejectVotes(id)),
+        "RejectVotes must be purged after cancel"
+    );
+    assert!(
+        !has_persistent_key(&env, &client, DataKey::ApproveWeight(id)),
+        "ApproveWeight must be purged after cancel"
+    );
+    assert!(
+        !has_persistent_key(&env, &client, DataKey::RejectWeight(id)),
+        "RejectWeight must be purged after cancel"
     );
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -3324,7 +3324,7 @@ fn test_vote_on_campaign_past_deadline_fails() {
     });
 
     let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
-    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
 }
 
 #[test]
@@ -3995,9 +3995,8 @@ fn test_verify_campaigns_extends_voting_state_ttl() {
     ));
 
     // Bulk verify the campaign
-    let (count, err) = client.verify_campaigns(&soroban_sdk::Vec::from_array(&env, [campaign_id]));
+    let count = client.verify_campaigns(&soroban_sdk::Vec::from_array(&env, [campaign_id]));
     assert_eq!(count, 1);
-    assert!(err.is_none());
 
     // Verify campaign is verified (confirming it worked)
     let campaign = client.get_campaign(&campaign_id);
@@ -4080,4 +4079,59 @@ fn test_claim_revenue_amount_raised_zero_guard() {
 
     let res = client.try_claim_revenue(&campaign_id, &contributor1);
     assert_eq!(res.unwrap_err().unwrap(), Error::AmountRaisedIsZero);
+}
+
+// ── Issue #379: cast_vote returns DeadlinePassed after deadline ───────────────
+
+#[test]
+fn test_vote_on_campaign_after_deadline_returns_deadline_passed() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &500);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Deadline Vote Test"),
+        String::from_str(&env, "Voting after deadline must return DeadlinePassed"),
+        1_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let campaign = client.get_campaign(&campaign_id);
+
+    // Advance past the deadline
+    env.ledger().with_mut(|li| {
+        li.timestamp = campaign.deadline + 1;
+    });
+
+    let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
+}
+
+// ── Issue #378: verify_campaigns returns Err on partial failure ───────────────
+
+#[test]
+fn test_verify_campaigns_partial_failure_returns_err() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Valid Campaign"),
+        String::from_str(&env, "One valid campaign"),
+        1_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    // 999 does not exist — will produce CampaignNotFound
+    let ids = soroban_sdk::Vec::from_array(&env, [campaign_id, 999u32]);
+    let res = client.try_verify_campaigns(&ids);
+    assert!(res.unwrap_err().is_ok()); // Err variant, inner Ok means contract error
 }

--- a/src/tests/test_purge_voting.rs
+++ b/src/tests/test_purge_voting.rs
@@ -72,13 +72,13 @@ fn test_purge_voting_state_non_finalize_keeps_aggregate() {
     let mut batch: Vec<Address> = Vec::new(&env);
     batch.push_back(voters.get(0).unwrap());
 
-    // Non-final batch — HasVoted for the supplied voter is cleared but the
-    // aggregate vote counts remain so the cleanup can continue across calls.
+    // Non-final batch — HasVoted for the supplied voter is cleared.
+    // The aggregate vote counts were already purged by cancel_campaign.
     client.purge_voting_state(&campaign_id, &batch, &false);
 
     assert!(!client.has_voted(&campaign_id, &voters.get(0).unwrap()));
     assert!(client.has_voted(&campaign_id, &voters.get(1).unwrap()));
-    assert_eq!(client.get_approve_votes(&campaign_id), 3);
+    assert_eq!(client.get_approve_votes(&campaign_id), 0);
 }
 
 #[test]
@@ -113,8 +113,8 @@ fn test_purge_voting_state_split_batches_then_finalize() {
     client.purge_voting_state(&campaign_id, &first, &false);
     assert_eq!(
         client.get_approve_votes(&campaign_id),
-        4,
-        "aggregate must survive the non-final batch"
+        0,
+        "aggregate was already purged by cancel_campaign"
     );
 
     client.purge_voting_state(&campaign_id, &second, &true);

--- a/src/tests/test_voting_verify.rs
+++ b/src/tests/test_voting_verify.rs
@@ -49,7 +49,7 @@ fn test_vote_on_campaign_past_deadline_fails() {
     });
 
     let res = client.try_vote_on_campaign(&campaign_id, &contributor1, &true);
-    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+    assert_eq!(res.unwrap_err().unwrap(), Error::DeadlinePassed);
 }
 
 #[test]

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -48,6 +48,7 @@ pub fn set_params(
 /// * `CampaignNotFound` - No campaign with the given ID.
 /// * `CampaignAlreadyVerified` - The campaign is already verified.
 /// * `CampaignNotActive` - The campaign is cancelled or inactive.
+/// * `DeadlinePassed` - The voting period has closed (deadline exceeded).
 /// * `NotTokenHolder` - The voter holds no tokens.
 /// * `AlreadyVoted` - The voter has already cast a vote on this campaign.
 pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> Result<(), Error> {
@@ -56,7 +57,7 @@ pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> 
     let campaign = get_campaign_or_error(env, campaign_id)?;
     require_active_campaign(&campaign)?;
     if env.ledger().timestamp() > campaign.deadline {
-        return Err(Error::CampaignNotActive);
+        return Err(Error::DeadlinePassed);
     }
     require_unverified_campaign(&campaign)?;
 

--- a/test_snapshots/test/test_cancel_and_refund.1.json
+++ b/test_snapshots/test/test_cancel_and_refund.1.json
@@ -796,52 +796,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "BlockContributionCount"
-                }
-              ]
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "BlockContributionCount"
-                    }
-                  ]
-                },
-                "durability": "temporary",
-                "val": {
-                  "vec": [
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "u32": 2
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
                   "symbol": "Campaign"
                 },
                 {
@@ -1382,6 +1336,28 @@
                         },
                         "val": {
                           "u32": 6000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "BlockCampaignContributionCount"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
                         }
                       },
                       {

--- a/test_snapshots/test/test_contribute_and_withdraw_success.1.json
+++ b/test_snapshots/test/test_contribute_and_withdraw_success.1.json
@@ -545,52 +545,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "BlockContributionCount"
-                }
-              ]
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "BlockContributionCount"
-                    }
-                  ]
-                },
-                "durability": "temporary",
-                "val": {
-                  "vec": [
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "u32": 1
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
                   "symbol": "Campaign"
                 },
                 {
@@ -1239,6 +1193,28 @@
                         },
                         "val": {
                           "u32": 6000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "BlockCampaignContributionCount"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
                         }
                       },
                       {

--- a/test_snapshots/test/test_failure_states.1.json
+++ b/test_snapshots/test/test_failure_states.1.json
@@ -547,52 +547,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "BlockContributionCount"
-                }
-              ]
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "BlockContributionCount"
-                    }
-                  ]
-                },
-                "durability": "temporary",
-                "val": {
-                  "vec": [
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "u32": 1
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
                   "symbol": "Campaign"
                 },
                 {
@@ -1133,6 +1087,28 @@
                         },
                         "val": {
                           "u32": 6000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "BlockCampaignContributionCount"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
                         }
                       },
                       {

--- a/test_snapshots/test/test_pull_based_revenue_distribution.1.json
+++ b/test_snapshots/test/test_pull_based_revenue_distribution.1.json
@@ -1133,52 +1133,6 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "BlockContributionCount"
-                }
-              ]
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "BlockContributionCount"
-                    }
-                  ]
-                },
-                "durability": "temporary",
-                "val": {
-                  "vec": [
-                    {
-                      "u32": 0
-                    },
-                    {
-                      "u32": 2
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          15
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
-            "key": {
-              "vec": [
-                {
                   "symbol": "Campaign"
                 },
                 {
@@ -2043,6 +1997,28 @@
                         },
                         "val": {
                           "u32": 6000
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "BlockCampaignContributionCount"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "u32": 0
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
                         }
                       },
                       {


### PR DESCRIPTION
  ## Summary

  - **#379** — `cast_vote` now returns `Error::DeadlinePassed` when the voting deadline has passed, distinguishing a
  closed voting window from a cancelled campaign (`CampaignNotActive`). `DeadlinePassed` (variant 8) already existed;
  this is a one-line fix in `src/voting.rs`.

  - **#380** — `cancel_campaign` now calls `remove_voting_state()` immediately after marking the campaign cancelled,
  purging the four aggregate voting keys (`ApproveVotes`, `RejectVotes`, `ApproveWeight`, `RejectWeight`) from persistent
   storage. Per-voter `HasVoted` entries still require admin cleanup via `purge_voting_state()`.

  - **#376** — The block-contribution burst counter is now stored in instance storage (`.instance()`) instead of
  temporary storage (`.temporary()`) for all four functions in `src/storage.rs`. The value already encodes the ledger
  sequence number, so stale data from a prior block is naturally superseded; no explicit cleanup needed.

  - **#378** — `verify_campaigns` return type simplified from `Result<(u32, Option<Error>), Error>` to `Result<u32,
  Error>`. Returns `Err(first_error)` when any campaign fails verification, so callers using a standard `Ok`/`Err` match
  cannot silently miss partial failures.

  ## Test plan
  - [x] `cargo test` — 338 tests pass, 0 failures
  - [x] New: `test_vote_on_campaign_after_deadline_returns_deadline_passed`
  - [x] New: `test_verify_campaigns_partial_failure_returns_err`
  - [x] New: `test_voting_keys_purged_after_cancel_with_prior_votes`
  - [x] Updated: existing deadline-vote tests corrected to `DeadlinePassed`
  - [x] Updated: `test_verify_campaigns_extends_voting_state_ttl` uses new `u32` return type
  - [x] Updated: `test_purge_voting` aggregate assertions corrected (aggregate cleared by `cancel_campaign`)

  Closes #376
  Closes #378
  Closes #379
  Closes #380