### PR TITLE
fix: emit description in update_campaign_description event payload

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,11 +718,11 @@ impl ProofOfHeart {
         }
 
         bump_instance_ttl(&env);
-        campaign.description = description;
+        campaign.description = description.clone();
         set_campaign(&env, campaign_id, &campaign);
 
         env.events()
-            .publish(("campaign_description_updated", campaign_id), ());
+            .publish(("campaign_description_updated", campaign_id), description);
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #356

## What changed
- `update_campaign_description` event now emits the new description string instead of empty `()`

## Why
Off-chain indexers were receiving a notification that a description changed but had no way to know the new value without making an额外 RPC call. This broke event-sourced architectures and added latency to UI updates.

## How to test
- Call `update_campaign_description` on a campaign
- Verify the emitted event contains the new description string in its payload
- Confirm indexers can read the description directly from the event stream

> **Note:** Issue #357 (PersonalCap cleanup in `claim_refund`) is already resolved on `main` — `remove_personal_cap` exists in `storage.rs` and is called in `claim_refund`.

Closes #356
Closes #357 