### PR TITLE
fix: defer revenue share division to prevent zero claimable on small pools

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -861,10 +861,13 @@ impl ProofOfHeart {
         }
 
         let total_pool = get_revenue_pool(&env, campaign_id);
-        let contributor_pool = (total_pool * (campaign.revenue_share_percentage as i128)) / 10000;
+        // Defer all division to the last step to avoid intermediate truncation to zero
+        // when total_pool is small relative to 10_000 / revenue_share_percentage (#375).
         let total_due = contribution
-            .checked_mul(contributor_pool)
+            .checked_mul(total_pool)
+            .and_then(|n| n.checked_mul(campaign.revenue_share_percentage as i128))
             .and_then(|n| n.checked_div(campaign.effective_amount_raised))
+            .and_then(|n| n.checked_div(10000))
             .ok_or(Error::Overflow)?;
         let already_claimed = get_revenue_claimed(&env, campaign_id, &contributor);
         let claimable = total_due - already_claimed;


### PR DESCRIPTION
Closes #373
Closes #375

**#375** (`claim_revenue`): The old code computed `contributor_pool = (total_pool * bps) / 10000` before multiplying by `contribution`, which floors to zero whenever `total_pool < 10_000 / bps`. The fix defers both divisions to the very end, keeping full precision throughout:

```rust
// Before (truncates to 0 when pool is small)
let contributor_pool = (total_pool * bps) / 10000;
let total_due = contribution.checked_mul(contributor_pool)...

// After (precision preserved)
let total_due = contribution
    .checked_mul(total_pool)
    .and_then(|n| n.checked_mul(bps))
    .and_then(|n| n.checked_div(effective_amount_raised))
    .and_then(|n| n.checked_div(10000))
    .ok_or(Error::Overflow)?;
```

**#373** (`deposit_revenue`): Already guarded by `if !campaign.funds_withdrawn { return Err(Error::ValidationFailed) }` in the current codebase — no additional change needed.