### PR TITLE
fix(contract,ci): P0 audit cleanup — discriminant, dead returns, CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,28 @@ on:
     branches: [main]
 
 jobs:
+  # Issue #403: enforce formatting on every PR.
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  # Issue #403: enforce clippy with -D warnings so unreachable_code and
+  # similar lints (see #401) cannot land silently again.
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+      - run: cargo clippy --all-targets --features testutils -- -D warnings
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,5 +84,5 @@ pub enum Error {
     /// The provided platform fee exceeds the maximum allowed basis points.
     InvalidPlatformFee = 39,
     /// A campaign transfer is already pending; cancel it before initiating a new one.
-    TransferAlreadyPending = 39,
+    TransferAlreadyPending = 40,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ impl ProofOfHeart {
         // a silently-clamped value. Matches the validation contract in
         // `update_platform_fee` and `set_campaign_fee_override`.
         if platform_fee > PLATFORM_FEE_MAX_BPS {
-            return Err(Error::ValidationFailed);
+            return Err(Error::InvalidPlatformFee);
         }
 
         // Validate that the address is a real SEP-41 token contract by probing
@@ -160,10 +160,6 @@ impl ProofOfHeart {
         )
         .map_err(|_| Error::InvalidTokenContract)?
         .map_err(|_| Error::InvalidTokenContract)?;
-
-        if platform_fee > PLATFORM_FEE_MAX_BPS {
-            return Err(Error::InvalidPlatformFee);
-        }
 
         bump_instance_ttl(&env);
         set_admin(&env, &admin);
@@ -1376,7 +1372,6 @@ impl ProofOfHeart {
         Self::require_not_paused(&env)?;
         if new_fee > PLATFORM_FEE_MAX_BPS {
             return Err(Error::InvalidPlatformFee);
-            return Err(Error::ValidationFailed);
         }
         let old_fee = get_platform_fee(&env);
         bump_instance_ttl(&env);

--- a/src/test.rs
+++ b/src/test.rs
@@ -106,9 +106,10 @@ fn test_platform_fee_cap_enforcement() {
     let contract_id = env.register_contract(None, ProofOfHeart);
     let client = ProofOfHeartClient::new(&env, &contract_id);
 
-    // Issue #343: init rejects fees above the cap rather than silently clamping.
+    // Issue #343 / #402: init rejects fees above the cap with InvalidPlatformFee
+    // (matching the CHANGELOG and update_platform_fee's contract).
     let res = client.try_init(&admin, &token_address, &5000);
-    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+    assert_eq!(res.unwrap_err().unwrap(), Error::InvalidPlatformFee);
 
     // Re-init with the maximum allowed fee and verify it applies end-to-end.
     client.init(&admin, &token_address, &1000);
@@ -1057,10 +1058,11 @@ fn test_update_platform_fee() {
     assert_eq!(data_vec.get(0).unwrap(), 300);
     assert_eq!(data_vec.get(1).unwrap(), 500);
 
-    // Issue #343: fees above the cap are rejected, not silently clamped.
+    // Issue #343 / #401: fees above the cap are rejected with InvalidPlatformFee.
+    // (The earlier duplicate ValidationFailed assertion was unreachable because
+    // update_platform_fee only ever returned InvalidPlatformFee — see #401.)
     let result = client.try_update_platform_fee(&5000);
     assert_eq!(result.unwrap_err().unwrap(), Error::InvalidPlatformFee);
-    assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Four P0 audit issues bundled into one PR.

- **#400 — Duplicate `Error` discriminant `39` breaks the build** (`src/errors.rs`): `TransferAlreadyPending = 39` collided with `InvalidPlatformFee = 39`. Reassigned to `40`. `cargo check` now exits 0 and `cargo build --target wasm32-unknown-unknown --release` produces a WASM artifact. The `TransferAlreadyPending` assertion already exists in `src/campaign_transfer_test.rs:54`.
- **#401 — Unreachable `return` in `update_platform_fee`** (`src/lib.rs`): dropped the dead second `return Err(Error::ValidationFailed)`. Also removed the impossible duplicate `assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed)` line in `src/test.rs` (it followed an assertion against `InvalidPlatformFee` on the same result and could never succeed). No more `unreachable_code` warning.
- **#402 — `init` validates `platform_fee` twice** (`src/lib.rs`): dropped the earlier check that returned `ValidationFailed` and kept the later check that returns `InvalidPlatformFee`, so `init` now matches the CHANGELOG and the assertions in `src/tests/test_init.rs`, `src/tests/test_admin.rs`, and the long-existing `src/test.rs:1062`. Updated `src/test.rs:111` (the `test_platform_fee_cap_enforcement` assertion) from `ValidationFailed` to `InvalidPlatformFee`.
- **#403 — CI does not run `fmt --check` or `clippy`** (`.github/workflows/ci.yml`): added two new jobs exactly as the issue proposes — `fmt` (running `cargo fmt --all -- --check`) and `clippy` (running `cargo clippy --all-targets --features testutils -- -D warnings`) — alongside the existing `test` job.

## Test plan

- [x] `cargo check` exits 0 (#400 acceptance).
- [x] `cargo build --target wasm32-unknown-unknown --release` produces a WASM artifact, no `unreachable_code` warning (#400 + #401 acceptance).
- [x] `cargo fmt -- --check` clean on the four files this PR touches (`src/errors.rs`, `src/lib.rs`, `src/test.rs`, `.github/workflows/ci.yml`).
- [x] `cargo test --features testutils` no longer fails on E0081 dup-discriminant; remaining test build errors are pre-existing (see below).

## ⚠️ Pre-existing cleanup deferred (out of scope)

A clean checkout of `main` already has substantial fmt/clippy/test debt that issue #403 itself acknowledges with *"Existing code passes both checks (may require a separate cleanup PR first — coordinate with #1, #2)"*:

- **Pre-existing test compile errors** (23 of them) in `src/test.rs` (`test_platform_fee_cap_enforcement` and a few neighbours) and `src/tests/test_init.rs` — these tests reference variables (`token`, `token_admin`, `contributor`, `creator`) that were never bound in their fixture. They exist on `main` before this branch and they have nothing to do with #400–#403. The test binary therefore won't compile until a cleanup PR fixes those fixtures.
- **Pre-existing rustfmt diffs** (~148 lines) and **pre-existing clippy warnings** in `src/issues_test.rs`, `src/lib.rs` (`manual_div_ceil` etc.) — these are exactly the kind of debt #403 is designed to prevent going forward, but they need a dedicated cleanup PR to fix.

After that cleanup PR lands, the new `fmt` / `clippy` jobs added here will be green.

Closes #400
Closes #401
Closes #402
Closes #403