### PR TITLE
chore: resolve pre-existing CI debt (test fixtures, fmt, clippy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `resume_campaign` now returns `ValidationFailed` when no pause is active, preventing spurious state writes and `campaign_resumed` events (#348).
 - `update_campaign` now emits both the updated title and description in `campaign_updated`, allowing full metadata indexing without extra reads (#349).
 
+### Infrastructure
+
+- Resolved pre-existing CI debt surfaced by the `fmt` and `clippy` gates added in #403: test fixture missing bindings restored in `src/test.rs` and `src/tests/test_init.rs`, `result` double-move fixed in `src/tests/test_admin.rs`, `cargo fmt --all` drift cleared across `src/issues_test.rs` and `src/lib.rs`, and clippy lints addressed (`manual_div_ceil` in `src/lib.rs`; `dead_code` suppressed on deferred storage helpers pending the DataKey audit in #409). All three CI jobs (`test`, `fmt`, `clippy`) now exit 0 on a clean checkout (#418).
+
 ### Refactored
 
 - Extracted `assert_admin(env, caller)` helper; used in `pause`, `unpause`, and `set_voting_params` to provide a single source of truth for admin authorization (#224).


### PR DESCRIPTION
Closes #418

## Context

All three CI buckets described in #418 were already resolved by prior commits on `main` (PRs #406 and #419) before this issue was assigned. This PR verifies that state and updates the CHANGELOG to formally record the cleanup.

## Verification

- **Bucket 1 (tests):** `cargo test --features testutils` — 345 tests pass, 0 failed.
- **Bucket 2 (fmt):** `cargo fmt --all -- --check` — exits 0, no drift.
- **Bucket 3 (clippy):** `cargo clippy --all-targets --features testutils -- -D warnings` — exits 0.

Latest CI run on `main` (push of #419): **success** across all three jobs.

## Test plan

- [x] `cargo test --features testutils` — 345 passed, 0 failed
- [x] `cargo fmt --all -- --check` — exits 0
- [x] `cargo clippy --all-targets --features testutils -- -D warnings` — exits 0
- [x] Maintainer: please mark `test`, `fmt`, and `clippy` as required status checks in branch protection on `main` to complete the loop from #403.