### PR TITLE
#390 [ENHANCEMENT] extend_campaign_deadline event omits old and new deadline values — indexers cannot reconstruct absolute deadline from the delta

### DIFF
--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -329,8 +329,8 @@ Every `publish(...)` call in the contract, with its topics, data shape, and the 
 | Field   | Value                                                      |
 |---------|------------------------------------------------------------|
 | Topics  | `("campaign_deadline_extended", campaign_id: u32)`         |
-| Data    | `additional_days: u64`                                     |
-| Source  | `lib.rs:1526` — `extend_campaign_deadline()`               |
+| Data    | `(old_deadline: u64, new_deadline: u64)`                   |
+| Source  | `src/campaigns/update.rs:82` — `extend_campaign_deadline()` |
 
 ---
 

--- a/src/campaigns/update.rs
+++ b/src/campaigns/update.rs
@@ -117,11 +117,15 @@ pub(crate) fn extend_campaign_deadline(
     }
 
     bump_instance_ttl(env);
+    let old_deadline = campaign.deadline;
     campaign.deadline = new_deadline;
     campaign.deadline_extended = true;
     set_campaign(env, campaign_id, &campaign);
 
     env.events()
-        .publish(("campaign_deadline_extended", campaign_id), additional_days);
+        .publish(
+            ("campaign_deadline_extended", campaign_id),
+            (old_deadline, campaign.deadline),
+        );
     Ok(())
 }

--- a/src/campaigns/update.rs
+++ b/src/campaigns/update.rs
@@ -122,10 +122,9 @@ pub(crate) fn extend_campaign_deadline(
     campaign.deadline_extended = true;
     set_campaign(env, campaign_id, &campaign);
 
-    env.events()
-        .publish(
-            ("campaign_deadline_extended", campaign_id),
-            (old_deadline, campaign.deadline),
-        );
+    env.events().publish(
+        ("campaign_deadline_extended", campaign_id),
+        (old_deadline, campaign.deadline),
+    );
     Ok(())
 }

--- a/src/tests/test_deadline_ext.rs
+++ b/src/tests/test_deadline_ext.rs
@@ -42,11 +42,16 @@ fn test_extend_deadline_emits_event() {
         0i128,
     ));
 
+    let original_deadline = client.get_campaign(&id).deadline;
     client.extend_campaign_deadline(&id, &5);
 
     let events = env.events().all();
     let last_event = events.last().unwrap();
     assert_eq!(last_event.1.len(), 2);
+
+    let payload: (u64, u64) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(payload.0, original_deadline);
+    assert_eq!(payload.1, original_deadline + 5 * 86400);
 }
 
 #[test]


### PR DESCRIPTION
## 📌 Description  #390 

Enhanced the `campaign_deadline_extended` event payload to include absolute deadline information, allowing indexers and auditors to reconstruct campaign deadlines directly from emitted events without relying on historical event data.

The event now emits the previous and updated deadline values, improving event traceability, indexing reliability, and auditability.

## 🔗 Related Issues

Closes #390

## 🧪 Changes Made

* [x] Enhancement
* [ ] Bug fix
* [ ] New feature
* [ ] Refactor
* [x] Documentation update

### Implementation

* Updated `campaign_deadline_extended` event payload to include deadline values.
* Improved event data completeness for indexers and external consumers.
* Added/updated tests to validate the new event structure.
* Updated relevant documentation where applicable.

## ✅ Checklist

* [x] Code compiles successfully
* [x] Tests added/updated and passing
* [x] Linting passes (no warnings/errors)
* [x] Documentation updated (if required)
* [x] No breaking changes (or clearly documented)



## 🧩 Additional Notes

This change enables consumers to determine the effective campaign deadline directly from event data, reducing reliance on reconstructing state from historical event sequences.
