### PR TITLE
[codex] Add category-specific funding goal caps

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -220,6 +220,42 @@ pub(crate) fn remove_category_duration_cap(
     Ok(())
 }
 
+pub(crate) fn set_category_funding_goal_cap(
+    env: &Env,
+    admin: Address,
+    category: crate::types::Category,
+    max_goal: i128,
+) -> Result<(), Error> {
+    assert_admin(env, &admin)?;
+    if max_goal <= 0 {
+        return Err(Error::FundingGoalMustBePositive);
+    }
+    if max_goal < get_min_campaign_funding_goal(env, crate::CAMPAIGN_FUNDING_GOAL_MIN) {
+        return Err(Error::ValidationFailed);
+    }
+    if max_goal > get_max_campaign_funding_goal(env, crate::CAMPAIGN_FUNDING_GOAL_MAX) {
+        return Err(Error::ValidationFailed);
+    }
+    bump_instance_ttl(env);
+    storage::set_category_funding_goal_cap(env, category, max_goal);
+    env.events()
+        .publish(("category_funding_goal_cap_set", category as u32), max_goal);
+    Ok(())
+}
+
+pub(crate) fn remove_category_funding_goal_cap(
+    env: &Env,
+    admin: Address,
+    category: crate::types::Category,
+) -> Result<(), Error> {
+    assert_admin(env, &admin)?;
+    bump_instance_ttl(env);
+    storage::remove_category_funding_goal_cap(env, category);
+    env.events()
+        .publish(("category_funding_goal_cap_removed", category as u32), ());
+    Ok(())
+}
+
 pub(crate) fn set_min_campaign_funding_goal_fn(
     env: &Env,
     admin: Address,

--- a/src/campaigns/create.rs
+++ b/src/campaigns/create.rs
@@ -4,12 +4,12 @@ use crate::errors::Error;
 use crate::lifecycle::{calculate_deadline, require_not_paused};
 use crate::storage::{
     bump_instance_ttl, get_campaign_count, get_category_campaign_bucket,
-    get_category_campaign_count, get_category_duration_cap, get_creation_disabled,
-    get_creator_campaign_bucket, get_creator_campaign_count, get_max_campaign_funding_goal,
-    get_min_campaign_funding_goal, set_campaign, set_campaign_count, set_campaign_start_time,
-    set_category_campaign_bucket, set_category_campaign_count, set_creator_campaign_bucket,
-    set_creator_campaign_count, set_revenue_pool, CATEGORY_CAMPAIGNS_BUCKET_SIZE,
-    CREATOR_CAMPAIGNS_BUCKET_SIZE,
+    get_category_campaign_count, get_category_duration_cap, get_category_funding_goal_cap,
+    get_creation_disabled, get_creator_campaign_bucket, get_creator_campaign_count,
+    get_max_campaign_funding_goal, get_min_campaign_funding_goal, set_campaign, set_campaign_count,
+    set_campaign_start_time, set_category_campaign_bucket, set_category_campaign_count,
+    set_creator_campaign_bucket, set_creator_campaign_count, set_revenue_pool,
+    CATEGORY_CAMPAIGNS_BUCKET_SIZE, CREATOR_CAMPAIGNS_BUCKET_SIZE,
 };
 use crate::types::{Campaign, Category, CreateCampaignParams, MaybePendingCreator};
 
@@ -38,7 +38,14 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
     if funding_goal < get_min_campaign_funding_goal(env, crate::CAMPAIGN_FUNDING_GOAL_MIN) {
         return Err(Error::FundingGoalTooLow);
     }
-    if funding_goal > get_max_campaign_funding_goal(env, crate::CAMPAIGN_FUNDING_GOAL_MAX) {
+    let global_max_goal = get_max_campaign_funding_goal(env, crate::CAMPAIGN_FUNDING_GOAL_MAX);
+    let category_max_goal = get_category_funding_goal_cap(env, category).unwrap_or(global_max_goal);
+    let effective_max_goal = if category_max_goal < global_max_goal {
+        category_max_goal
+    } else {
+        global_max_goal
+    };
+    if funding_goal > effective_max_goal {
         return Err(Error::FundingGoalTooHigh);
     }
     let duration_max =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,23 @@ impl ProofOfHeart {
         admin::remove_category_duration_cap(&env, admin, category)
     }
 
+    pub fn set_category_funding_goal_cap(
+        env: Env,
+        admin: Address,
+        category: Category,
+        max_goal: i128,
+    ) -> Result<(), Error> {
+        admin::set_category_funding_goal_cap(&env, admin, category, max_goal)
+    }
+
+    pub fn remove_category_funding_goal_cap(
+        env: Env,
+        admin: Address,
+        category: Category,
+    ) -> Result<(), Error> {
+        admin::remove_category_funding_goal_cap(&env, admin, category)
+    }
+
     pub fn set_min_campaign_funding_goal(
         env: Env,
         admin: Address,
@@ -454,6 +471,14 @@ impl ProofOfHeart {
 
     pub fn get_max_campaign_funding_goal(env: Env) -> i128 {
         get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX)
+    }
+
+    pub fn get_category_funding_goal_cap(env: Env, category: Category) -> i128 {
+        let global_max_goal = get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX);
+        match storage::get_category_funding_goal_cap(&env, category) {
+            Some(category_max_goal) if category_max_goal < global_max_goal => category_max_goal,
+            _ => global_max_goal,
+        }
     }
 
     pub fn get_min_voting_balance(env: Env) -> i128 {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -109,6 +109,8 @@ pub enum DataKey {
     VerifiedCampaignCount,
     /// Number of campaigns that have been cancelled.
     CancelledCampaignCount,
+    /// Per-category maximum funding goal cap, keyed by category discriminant.
+    CategoryFundingGoalCap(u32),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -248,6 +250,24 @@ pub fn set_max_campaign_funding_goal(env: &Env, max_goal: i128) {
     env.storage()
         .instance()
         .set(&DataKey::MaxCampaignFundingGoal, &max_goal);
+}
+
+/// Returns the maximum funding goal configured for a category, if present.
+pub fn get_category_funding_goal_cap(env: &Env, category: Category) -> Option<i128> {
+    let key = DataKey::CategoryFundingGoalCap(category as u32);
+    env.storage().instance().get(&key)
+}
+
+/// Stores the maximum funding goal configured for a category.
+pub fn set_category_funding_goal_cap(env: &Env, category: Category, max_goal: i128) {
+    let key = DataKey::CategoryFundingGoalCap(category as u32);
+    env.storage().instance().set(&key, &max_goal);
+}
+
+/// Removes a per-category funding goal cap, reverting to the global maximum.
+pub fn remove_category_funding_goal_cap(env: &Env, category: Category) {
+    let key = DataKey::CategoryFundingGoalCap(category as u32);
+    env.storage().instance().remove(&key);
 }
 
 // ── Contributions ─────────────────────────────────────────────────────────────

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod test_benchmark;
 mod test_campaign_create;
 mod test_campaign_update;
 mod test_cancel_revenue_orphan;
+mod test_category_funding_goal_cap;
 mod test_contribute;
 mod test_contribute_caps;
 mod test_create_campaign_proptest;

--- a/src/tests/test_category_funding_goal_cap.rs
+++ b/src/tests/test_category_funding_goal_cap.rs
@@ -1,0 +1,148 @@
+use super::helpers::*;
+use crate::{Category, Error, CAMPAIGN_FUNDING_GOAL_MAX};
+use soroban_sdk::{Address, String};
+
+#[test]
+fn test_category_funding_goal_cap_enforced() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_funding_goal_cap(&admin, &Category::Educator, &500);
+    assert_eq!(
+        client.get_category_funding_goal_cap(&Category::Educator),
+        500
+    );
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Educator high"),
+        String::from_str(&env, "Too much"),
+        501,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooHigh);
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Educator OK"),
+        String::from_str(&env, "Within cap"),
+        500,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_category_funding_goal_cap_other_categories_unaffected() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_funding_goal_cap(&admin, &Category::Learner, &500);
+
+    let educator_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Educator"),
+        String::from_str(&env, "Global cap still applies"),
+        1_000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(educator_id, 1);
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Learner"),
+        String::from_str(&env, "Too much"),
+        501,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooHigh);
+}
+
+#[test]
+fn test_remove_category_funding_goal_cap_reverts_to_global_max() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_funding_goal_cap(&admin, &Category::Publisher, &500);
+    client.remove_category_funding_goal_cap(&admin, &Category::Publisher);
+    assert_eq!(
+        client.get_category_funding_goal_cap(&Category::Publisher),
+        CAMPAIGN_FUNDING_GOAL_MAX
+    );
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Publisher"),
+        String::from_str(&env, "Back to global max"),
+        1_000,
+        30,
+        Category::Publisher,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_category_funding_goal_cap_respects_lower_global_max() {
+    let (env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    client.set_category_funding_goal_cap(&admin, &Category::Learner, &1_000);
+    client.set_max_campaign_funding_goal(&admin, &800);
+    assert_eq!(
+        client.get_category_funding_goal_cap(&Category::Learner),
+        800
+    );
+
+    let res = client.try_create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Learner high"),
+        String::from_str(&env, "Above global"),
+        801,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0,
+    ));
+    assert_eq!(res.unwrap_err().unwrap(), Error::FundingGoalTooHigh);
+}
+
+#[test]
+fn test_category_funding_goal_cap_validation() {
+    let (_env, admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let zero = client.try_set_category_funding_goal_cap(&admin, &Category::Learner, &0);
+    assert_eq!(zero.unwrap_err().unwrap(), Error::FundingGoalMustBePositive);
+
+    client.set_min_campaign_funding_goal(&admin, &100);
+    let below_min = client.try_set_category_funding_goal_cap(&admin, &Category::Learner, &99);
+    assert_eq!(below_min.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    client.set_max_campaign_funding_goal(&admin, &800);
+    let above_global = client.try_set_category_funding_goal_cap(&admin, &Category::Learner, &801);
+    assert_eq!(above_global.unwrap_err().unwrap(), Error::ValidationFailed);
+}
+
+#[test]
+fn test_category_funding_goal_cap_non_admin_rejected() {
+    let (env, _admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let impostor = Address::generate(&env);
+    let res = client.try_set_category_funding_goal_cap(&impostor, &Category::Learner, &500);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}


### PR DESCRIPTION
## Summary
- add per-category funding goal cap storage keyed by campaign category
- expose admin set/remove helpers plus a getter for the effective category cap
- enforce the stricter of the category cap and global max during `create_campaign`
- add focused tests for enforcement, category isolation, removal, validation, and non-admin rejection

Fixes #509.

## Validation
- `git diff --check`
- static brace-balance sanity check on touched Rust files

I could not run `cargo fmt` / `cargo test` locally because this Windows environment does not have `cargo` or `rustc` installed.