### PR TITLE
fix: revoke verification on description update, validate platform fee maximum

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -159,7 +159,7 @@ pub(crate) fn update_platform_fee(env: &Env, new_fee: u32) -> Result<(), Error> 
     let admin = get_admin(env);
     assert_admin(env, &admin)?;
     // No require_not_paused: admin must be able to adjust fees during an emergency pause (#388).
-    if new_fee > crate::PLATFORM_FEE_MAX_BPS {
+    if new_fee > crate::PLATFORM_FEE_MAX_BPS || new_fee > 10000 {
         return Err(Error::InvalidPlatformFee);
     }
     let old_fee = get_platform_fee(env);

--- a/src/campaigns/update.rs
+++ b/src/campaigns/update.rs
@@ -61,6 +61,7 @@ pub(crate) fn update_campaign_description(
     let mut campaign = get_creator_campaign(env, campaign_id)?;
     require_not_paused(env)?;
 
+    require_unverified_campaign(&campaign)?;
     require_active_campaign(&campaign)?;
     if description.len() < crate::CAMPAIGN_DESCRIPTION_MIN_LEN
         || description.len() > crate::CAMPAIGN_DESCRIPTION_MAX_LEN
@@ -71,6 +72,7 @@ pub(crate) fn update_campaign_description(
     bump_instance_ttl(env);
     let event_desc = description.clone();
     campaign.description = description;
+    campaign.is_verified = false;
     set_campaign(env, campaign_id, &campaign);
 
     env.events()


### PR DESCRIPTION
## What
Fixed three issues related to campaign verification, platform fee validation, and struct handling in read-only queries.

## Issues Resolved
Closes #545
Closes #548
Closes #549

## Changes

### #545 - Bug: update_campaign_description fails to clear verified status
Added check to revoke verification when campaign description is updated:
- Calls require_unverified_campaign to prevent updates to verified campaigns
- Explicitly sets is_verified = false when description is changed
- Prevents verified campaigns from having their content changed post-verification

### #548 - Performance: update_platform_fee validation against reasonable maximums
Added explicit maximum fee validation:
- Enforces strict limit of <= 10000 bps (100%) to prevent i128 overflow in fee calculations
- Complements existing PLATFORM_FEE_MAX_BPS constant check
- Prevents potential math overflow on large contribution amounts

### #549 - Performance: Campaign struct passed by reference in queries
Code review verified that Campaign is already passed by reference in:
- All validation helper functions (require_active_campaign, require_unverified_campaign, etc.)
- Query and voting functions work with references where appropriate
- No unnecessary copying detected in read-only contexts