### PR TITLE
Revert #574 to restore green main

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,14 +4,14 @@ use crate::errors::Error;
 use crate::lifecycle::{assert_admin, get_campaign_or_error, require_active_campaign};
 use crate::storage::{
     self, bump_instance_ttl, get_active_campaign_count, get_admin, get_approval_threshold_bps,
-    get_campaign_milestones, get_emergency_pause_signers, get_max_campaign_funding_goal, get_min_campaign_funding_goal, get_min_votes_quorum,
+    get_max_campaign_funding_goal, get_min_campaign_funding_goal, get_min_votes_quorum,
     get_pending_admin, get_pending_token, get_pending_token_release, get_platform_fee, get_token,
     get_total_raised_global, get_version, is_initialized, remove_has_voted, remove_pending_admin,
     remove_pending_token, remove_voting_state, set_admin, set_approval_threshold_bps,
-    set_campaign_count, set_campaign_milestones, set_creation_disabled, set_emergency_pause_signers, set_initialized, set_max_campaign_funding_goal,
+    set_campaign_count, set_creation_disabled, set_initialized, set_max_campaign_funding_goal,
     set_min_campaign_funding_goal, set_min_votes_quorum, set_min_voting_balance, set_pending_admin,
     set_pending_token, set_pending_token_release, set_platform_fee, set_token,
-    set_total_raised_global, set_version, set_campaign_milestone_count, set_withdraw_release_delay_days,
+    set_total_raised_global, set_version, set_withdraw_release_delay_days,
     set_withdraw_reserve_percentage, DataKey,
 };
 use crate::voting;
@@ -85,38 +85,6 @@ pub(crate) fn unpause(env: &Env) -> Result<(), Error> {
     env.storage().instance().set(&DataKey::Paused, &false);
     env.storage().instance().set(&DataKey::AutoPaused, &false);
     env.events().publish(("contract_unpaused", admin), ());
-    Ok(())
-}
-
-pub(crate) fn set_emergency_pause_signers(
-    env: &Env,
-    admin: Address,
-    signers: Vec<Address>,
-) -> Result<(), Error> {
-    assert_admin(env, &admin)?;
-    if signers.is_empty() {
-        return Err(Error::ValidationFailed);
-    }
-    bump_instance_ttl(env);
-    storage::set_emergency_pause_signers(env, &signers);
-    env.events()
-        .publish(("emergency_pause_signers_updated",), signers.len());
-    Ok(())
-}
-
-pub(crate) fn emergency_pause(env: &Env, caller: Address) -> Result<(), Error> {
-    caller.require_auth();
-    let signers = get_emergency_pause_signers(env);
-    if signers.is_empty() {
-        return Err(Error::NotAuthorized);
-    }
-    let is_authorized = signers.iter().any(|s| s == &caller);
-    if !is_authorized {
-        return Err(Error::NotAuthorized);
-    }
-    bump_instance_ttl(env);
-    env.storage().instance().set(&DataKey::Paused, &true);
-    env.events().publish(("emergency_paused", caller), ());
     Ok(())
 }
 
@@ -498,57 +466,5 @@ pub(crate) fn resume_campaign(env: &Env, campaign_id: u32, caller: Address) -> R
     env.events()
         .publish(("campaign_resumed", campaign_id, caller), ());
 
-    Ok(())
-}
-
-pub(crate) fn add_campaign_milestones(
-    env: &Env,
-    admin: Address,
-    campaign_id: u32,
-    milestones: Vec<crate::types::Milestone>,
-) -> Result<(), Error> {
-    assert_admin(env, &admin)?;
-    let campaign = get_campaign_or_error(env, campaign_id)?;
-    if !campaign.uses_milestones {
-        return Err(Error::ValidationFailed);
-    }
-    if milestones.is_empty() {
-        return Err(Error::ValidationFailed);
-    }
-
-    bump_instance_ttl(env);
-    set_campaign_milestones(env, campaign_id, &milestones);
-    set_campaign_milestone_count(env, campaign_id, milestones.len() as u32);
-    env.events()
-        .publish(("campaign_milestones_added", campaign_id), milestones.len());
-    Ok(())
-}
-
-pub(crate) fn verify_milestone(
-    env: &Env,
-    admin: Address,
-    campaign_id: u32,
-    milestone_id: u32,
-) -> Result<(), Error> {
-    assert_admin(env, &admin)?;
-    get_campaign_or_error(env, campaign_id)?;
-
-    let mut milestones = get_campaign_milestones(env, campaign_id);
-    let mut found = false;
-    for m in milestones.iter_mut() {
-        if m.id == milestone_id {
-            m.verified = true;
-            found = true;
-            break;
-        }
-    }
-    if !found {
-        return Err(Error::ValidationFailed);
-    }
-
-    bump_instance_ttl(env);
-    set_campaign_milestones(env, campaign_id, &milestones);
-    env.events()
-        .publish(("milestone_verified", campaign_id, milestone_id), ());
     Ok(())
 }

--- a/src/campaigns/create.rs
+++ b/src/campaigns/create.rs
@@ -6,7 +6,7 @@ use crate::storage::{
     bump_instance_ttl, get_campaign_count, get_category_campaign_bucket,
     get_category_campaign_count, get_category_duration_cap, get_creation_disabled,
     get_creator_campaign_bucket, get_creator_campaign_count, get_max_campaign_funding_goal,
-    get_min_campaign_funding_goal, get_token, set_campaign, set_campaign_count, set_campaign_start_time,
+    get_min_campaign_funding_goal, set_campaign, set_campaign_count, set_campaign_start_time,
     set_category_campaign_bucket, set_category_campaign_count, set_creator_campaign_bucket,
     set_creator_campaign_count, set_revenue_pool, CATEGORY_CAMPAIGNS_BUCKET_SIZE,
     CREATOR_CAMPAIGNS_BUCKET_SIZE,
@@ -30,8 +30,6 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
         has_revenue_sharing,
         revenue_share_percentage,
         max_contribution_per_user,
-        token,
-        uses_milestones,
     } = params;
 
     if funding_goal <= 0 {
@@ -60,6 +58,8 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
         return Err(Error::RevenueShareOnlyForStartup);
     }
 
+    // Normalise: force percentage to 0 when revenue sharing is disabled so
+    // the stored (has_revenue_sharing, percentage) pair is always coherent.
     let revenue_share_percentage = if !has_revenue_sharing {
         0u32
     } else {
@@ -82,19 +82,6 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
 
     let deadline = calculate_deadline(env.ledger().timestamp(), duration_days)?;
 
-    let campaign_token = if let Some(t) = token {
-        env.try_invoke_contract::<u32, Error>(
-            &t,
-            &soroban_sdk::Symbol::new(env, "decimals"),
-            soroban_sdk::Vec::new(env),
-        )
-        .map_err(|_| Error::InvalidTokenContract)?
-        .map_err(|_| Error::InvalidTokenContract)?;
-        t
-    } else {
-        get_token(env)
-    };
-
     let campaign = Campaign {
         id: count,
         creator: creator.clone(),
@@ -116,8 +103,6 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
         fee_override: None,
         deadline_extended: false,
         effective_amount_raised: 0,
-        token: campaign_token,
-        uses_milestones,
     };
 
     set_campaign(env, count, &campaign);

--- a/src/campaigns/withdraw.rs
+++ b/src/campaigns/withdraw.rs
@@ -3,11 +3,10 @@ use soroban_sdk::Env;
 use crate::errors::Error;
 use crate::lifecycle::{
     get_campaign_or_error, get_creator_campaign, require_not_paused, token_client,
-    token_client_for_address,
 };
 use crate::storage::{
-    bump_instance_ttl, decrement_active_campaign_count, get_admin, get_campaign_milestones,
-    get_campaign_reserve, get_platform_fee, get_total_raised_global, get_withdraw_release_delay_days,
+    bump_instance_ttl, decrement_active_campaign_count, get_admin, get_campaign_reserve,
+    get_platform_fee, get_total_raised_global, get_withdraw_release_delay_days,
     get_withdraw_reserve_percentage, set_campaign, set_campaign_reserve, set_total_raised_global,
     set_withdraw_release_delay_days, set_withdraw_reserve_percentage,
 };
@@ -17,6 +16,9 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
     let mut campaign = get_creator_campaign(env, campaign_id)?;
     require_not_paused(env)?;
 
+    // Defense-in-depth: re-check verification even though `contribute`
+    // already requires it, in case a future code path seeds an unverified
+    // campaign directly (admin grant, migration, etc.).
     if !campaign.is_verified {
         return Err(Error::CampaignNotVerified);
     }
@@ -35,18 +37,12 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
         return Err(Error::FundingGoalNotReached);
     }
 
-    if campaign.uses_milestones {
-        let milestones = get_campaign_milestones(env, campaign_id);
-        let all_verified = milestones.iter().all(|m| m.verified);
-        if !all_verified {
-            return Err(Error::ValidationFailed);
-        }
-    }
-
     bump_instance_ttl(env);
     let platform_fee = campaign
         .fee_override
         .unwrap_or_else(|| get_platform_fee(env));
+    // Ceiling division: ceil(a / b) = (a + b - 1) / b. Use checked arithmetic so
+    // a pathological amount_raised yields Error::Overflow rather than a panic (#408).
     let fee_amount = campaign
         .amount_raised
         .checked_mul(platform_fee as i128)
@@ -63,8 +59,9 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
         / 10000;
     let creator_amount = total_after_fee - reserve_amount;
 
+    // Execute token transfers BEFORE marking campaign as withdrawn to prevent stuck state
     let admin_addr = get_admin(env);
-    let client = token_client_for_address(env, &campaign.token);
+    let client = token_client(env);
 
     client.transfer(&env.current_contract_address(), &admin_addr, &fee_amount);
     client.transfer(
@@ -73,6 +70,7 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
         &creator_amount,
     );
 
+    // Update state only after successful external interactions
     campaign.funds_withdrawn = true;
     campaign.is_active = false;
     set_campaign(env, campaign_id, &campaign);
@@ -128,13 +126,15 @@ pub(crate) fn withdraw_reserve(env: &Env, campaign_id: u32) -> Result<(), Error>
     let campaign = get_campaign_or_error(env, campaign_id)?;
     campaign.creator.require_auth();
 
-    let client = token_client_for_address(env, &campaign.token);
+    // Transfer funds BEFORE marking reserve as released to prevent stuck state
+    let client = token_client(env);
     client.transfer(
         &env.current_contract_address(),
         &campaign.creator,
         &reserve.amount,
     );
 
+    // Update state only after successful external interaction
     reserve.released = true;
     set_campaign_reserve(env, campaign_id, &reserve);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,18 +249,6 @@ impl ProofOfHeart {
         admin::unpause(&env)
     }
 
-    pub fn emergency_pause(env: Env, caller: Address) -> Result<(), Error> {
-        admin::emergency_pause(&env, caller)
-    }
-
-    pub fn set_emergency_pause_signers(
-        env: Env,
-        admin: Address,
-        signers: soroban_sdk::Vec<Address>,
-    ) -> Result<(), Error> {
-        admin::set_emergency_pause_signers(&env, admin, signers)
-    }
-
     pub fn is_paused(env: Env) -> bool {
         env.storage()
             .instance()
@@ -538,32 +526,6 @@ impl ProofOfHeart {
 
     pub fn get_platform_stats(env: Env) -> PlatformStats {
         queries::get_platform_stats(&env)
-    }
-
-    pub fn add_campaign_milestones(
-        env: Env,
-        admin: Address,
-        campaign_id: u32,
-        milestones: soroban_sdk::Vec<types::Milestone>,
-    ) -> Result<(), Error> {
-        admin::add_campaign_milestones(&env, admin, campaign_id, milestones)
-    }
-
-    pub fn verify_milestone(
-        env: Env,
-        admin: Address,
-        campaign_id: u32,
-        milestone_id: u32,
-    ) -> Result<(), Error> {
-        admin::verify_milestone(&env, admin, campaign_id, milestone_id)
-    }
-
-    pub fn get_campaign_milestones(env: Env, campaign_id: u32) -> soroban_sdk::Vec<types::Milestone> {
-        storage::get_campaign_milestones(&env, campaign_id)
-    }
-
-    pub fn get_campaign_milestone_count(env: Env, campaign_id: u32) -> u32 {
-        storage::get_campaign_milestone_count(&env, campaign_id)
     }
 }
 

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -79,10 +79,6 @@ pub(crate) fn token_client(env: &Env) -> token::Client<'_> {
     token::Client::new(env, &get_token(env))
 }
 
-pub(crate) fn token_client_for_address(env: &Env, token_addr: &Address) -> token::Client<'_> {
-    token::Client::new(env, token_addr)
-}
-
 pub(crate) fn campaign_start_time_or_error(env: &Env, campaign_id: u32) -> Result<u64, Error> {
     get_campaign_start_time(env, campaign_id).ok_or(Error::InvalidDuration)
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -109,12 +109,6 @@ pub enum DataKey {
     VerifiedCampaignCount,
     /// Number of campaigns that have been cancelled.
     CancelledCampaignCount,
-    /// Emergency pause signers set by admin.
-    EmergencyPauseSigners,
-    /// Milestones for a campaign, keyed by campaign ID.
-    CampaignMilestones(u32),
-    /// Count of milestones for a campaign.
-    CampaignMilestoneCount(u32),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -913,50 +907,4 @@ pub fn set_cancelled_campaign_count(env: &Env, count: u32) {
 
 pub fn increment_cancelled_campaign_count(env: &Env) {
     set_cancelled_campaign_count(env, get_cancelled_campaign_count(env) + 1);
-}
-
-// ── Emergency pause signers ───────────────────────────────────────────
-
-pub fn get_emergency_pause_signers(env: &Env) -> Vec<Address> {
-    env.storage()
-        .instance()
-        .get(&DataKey::EmergencyPauseSigners)
-        .unwrap_or_else(|| Vec::new(env))
-}
-
-pub fn set_emergency_pause_signers(env: &Env, signers: &Vec<Address>) {
-    env.storage()
-        .instance()
-        .set(&DataKey::EmergencyPauseSigners, signers);
-}
-
-// ── Campaign milestones ───────────────────────────────────────────────
-
-pub fn get_campaign_milestones(env: &Env, campaign_id: u32) -> Vec<crate::types::Milestone> {
-    let key = DataKey::CampaignMilestones(campaign_id);
-    env.storage()
-        .persistent()
-        .get(&key)
-        .unwrap_or_else(|| Vec::new(env))
-}
-
-pub fn set_campaign_milestones(env: &Env, campaign_id: u32, milestones: &Vec<crate::types::Milestone>) {
-    let key = DataKey::CampaignMilestones(campaign_id);
-    env.storage().persistent().set(&key, milestones);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
-}
-
-pub fn get_campaign_milestone_count(env: &Env, campaign_id: u32) -> u32 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::CampaignMilestoneCount(campaign_id))
-        .unwrap_or(0)
-}
-
-pub fn set_campaign_milestone_count(env: &Env, campaign_id: u32, count: u32) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::CampaignMilestoneCount(campaign_id), &count);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contracttype, Address, String};
 
 /// Represents an optional pending campaign creator for ownership transfers.
 /// Mirrors `Option<Address>` — used instead of the standard `Option` because
@@ -26,20 +26,6 @@ impl From<Address> for MaybePendingCreator {
     fn from(addr: Address) -> Self {
         MaybePendingCreator::Some(addr)
     }
-}
-
-/// Represents a funding milestone for milestone-based withdrawals.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Milestone {
-    /// Unique identifier for the milestone.
-    pub id: u32,
-    /// Target amount to be reached for this milestone.
-    pub target_amount: i128,
-    /// Description of the milestone.
-    pub description: String,
-    /// Whether this milestone has been verified by admin/community.
-    pub verified: bool,
 }
 
 /// Represents a category for a campaign, determining its type and eligibility for revenue sharing.
@@ -100,10 +86,6 @@ pub struct Campaign {
     pub deadline_extended: bool,
     /// Total live contributions remaining after refunds, used for revenue-sharing pro-rata.
     pub effective_amount_raised: i128,
-    /// Token address for this campaign. Can differ from global token.
-    pub token: Address,
-    /// Whether this campaign uses milestone-based withdrawals.
-    pub uses_milestones: bool,
 }
 
 /// Aggregate platform metrics for dashboard and indexer consumers.
@@ -151,10 +133,6 @@ pub struct CreateCampaignParams {
     pub revenue_share_percentage: u32,
     /// Per-user contribution cap in tokens. `0` means no cap.
     pub max_contribution_per_user: i128,
-    /// Token address for this campaign. If None, uses global default.
-    pub token: Option<Address>,
-    /// Whether this campaign uses milestone-based withdrawals.
-    pub uses_milestones: bool,
 }
 
 /// Stores details about withheld funds for a campaign.


### PR DESCRIPTION
## Reverts #574 to restore a green main

**Why:** #574 ("feat: emergency pause, milestone withdrawals, and per-campaign tokens") was merged on 2026-07-01 while its own CI was red, and it does not compile. main has been broken ever since, which is why **every open stellar PR shows the same errors** (fmt/clippy/test) — they all rebase/merge onto a broken main.

The breakage in #574:
- duplicate `set_emergency_pause_signers` import vs the local fn (E0255)
- missing lifetime on `token_client_for_address` (E0106)
- `Vec::iter_mut` in `verify_milestone` (unsupported by soroban Vec, E0599)
- `s == &caller` type mismatch in `emergency_pause` (E0308)
- unused imports `Vec`, `token_client`, `set_emergency_pause_signers` (fail `-D warnings`)
- ~33 test call-sites missing the new `token`/`uses_milestones` fields on both `CreateCampaignParams` and `Campaign` (E0063)
- **E0277**: `token: Option<Address>` in a `#[contracttype]` struct is not ScVal-convertible in the pinned soroban-sdk — this one is a real data-model issue, not mechanical.

This revert restores the last green commit (368b0f61). The feature should be re-submitted as a fresh PR with passing CI (the `Option<Address>` representation needs rethinking so it satisfies `#[contracttype]`).

cc @logantalen — happy to help get the re-submit green.
