### PR TITLE
feat: add on-chain comment censure flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `resume_campaign` now returns `ValidationFailed` when no pause is active, preventing spurious state writes and `campaign_resumed` events (#348).
 - `update_campaign` now emits both the updated title and description in `campaign_updated`, allowing full metadata indexing without extra reads (#349).
 
+### Added
+
+- `censure_comment` admin entry point that marks an off-chain campaign comment as censured on-chain under `DataKey::CommentCensured(campaign_id, comment_hash)`, emitting `comment_censured`; the flag is readable via `is_comment_censured` (#542).
+
 ### Infrastructure
 
 - Resolved pre-existing CI debt surfaced by the `fmt` and `clippy` gates added in #403: test fixture missing bindings restored in `src/test.rs` and `src/tests/test_init.rs`, `result` double-move fixed in `src/tests/test_admin.rs`, `cargo fmt --all` drift cleared across `src/issues_test.rs` and `src/lib.rs`, and clippy lints addressed (`manual_div_ceil` in `src/lib.rs`; `dead_code` suppressed on deferred storage helpers pending the DataKey audit in #409). All three CI jobs (`test`, `fmt`, `clippy`) now exit 0 on a clean checkout (#418).

--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -454,6 +454,16 @@ Every `publish(...)` call in the contract, with its topics, data shape, and the 
 
 ---
 
+### `comment_censured`
+
+| Field   | Value                                                      |
+|---------|------------------------------------------------------------|
+| Topics  | `("comment_censured", campaign_id: u32, admin: Address)`   |
+| Data    | `comment_hash: BytesN<32>`                                 |
+| Source  | `admin.rs:466` - `censure_comment()`                       |
+
+---
+
 ### `campaign_vote_cast`
 
 | Field   | Value                                                      |

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, Vec};
+use soroban_sdk::{Address, BytesN, Env, Vec};
 
 use crate::errors::Error;
 use crate::lifecycle::{assert_admin, get_campaign_or_error, require_active_campaign};
@@ -446,6 +446,25 @@ pub(crate) fn purge_voting_state(
             .publish(("voting_state_purged", campaign_id), ());
     }
 
+    Ok(())
+}
+
+pub(crate) fn censure_comment(
+    env: &Env,
+    admin: Address,
+    campaign_id: u32,
+    comment_hash: BytesN<32>,
+) -> Result<(), Error> {
+    assert_admin(env, &admin)?;
+    // No require_not_paused: comment moderation is admin governance (#388).
+    get_campaign_or_error(env, campaign_id)?;
+    if storage::get_comment_censured(env, campaign_id, &comment_hash) {
+        return Err(Error::ValidationFailed);
+    }
+    bump_instance_ttl(env);
+    storage::set_comment_censured(env, campaign_id, &comment_hash);
+    env.events()
+        .publish(("comment_censured", campaign_id, admin), comment_hash);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod types;
 mod voting;
 
 pub use errors::Error;
-use soroban_sdk::{contract, contractimpl, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 pub use storage::DataKey;
 use storage::*;
 pub use types::*;
@@ -232,6 +232,19 @@ impl ProofOfHeart {
 
     pub fn resume_campaign(env: Env, campaign_id: u32, caller: Address) -> Result<(), Error> {
         admin::resume_campaign(&env, campaign_id, caller)
+    }
+
+    pub fn censure_comment(
+        env: Env,
+        admin: Address,
+        campaign_id: u32,
+        comment_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        admin::censure_comment(&env, admin, campaign_id, comment_hash)
+    }
+
+    pub fn is_comment_censured(env: Env, campaign_id: u32, comment_hash: BytesN<32>) -> bool {
+        get_comment_censured(&env, campaign_id, &comment_hash)
     }
 
     pub fn purge_voting_state(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 
 use crate::types::{Campaign, CampaignReserve, Category};
 
@@ -109,6 +109,8 @@ pub enum DataKey {
     VerifiedCampaignCount,
     /// Number of campaigns that have been cancelled.
     CancelledCampaignCount,
+    /// Whether an off-chain comment was censured by admin, keyed by `(campaign_id, comment_hash)`.
+    CommentCensured(u32, BytesN<32>),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -907,4 +909,19 @@ pub fn set_cancelled_campaign_count(env: &Env, count: u32) {
 
 pub fn increment_cancelled_campaign_count(env: &Env) {
     set_cancelled_campaign_count(env, get_cancelled_campaign_count(env) + 1);
+}
+
+/// Returns whether a comment has been censured for a campaign.
+pub fn get_comment_censured(env: &Env, campaign_id: u32, comment_hash: &BytesN<32>) -> bool {
+    let key = DataKey::CommentCensured(campaign_id, comment_hash.clone());
+    env.storage().persistent().get(&key).unwrap_or(false)
+}
+
+/// Records that a comment was censured and extends the entry's TTL.
+pub fn set_comment_censured(env: &Env, campaign_id: u32, comment_hash: &BytesN<32>) {
+    let key = DataKey::CommentCensured(campaign_id, comment_hash.clone());
+    env.storage().persistent().set(&key, &true);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod test_campaign_create;
 mod test_campaign_update;
 mod test_cancel_after_goal_met;
 mod test_cancel_revenue_orphan;
+mod test_comment_censure;
 mod test_contribute;
 mod test_contribute_caps;
 mod test_create_campaign_proptest;

--- a/src/tests/test_comment_censure.rs
+++ b/src/tests/test_comment_censure.rs
@@ -1,0 +1,94 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::BytesN;
+
+fn create_campaign(env: &Env, creator: &Address, client: &ProofOfHeartClient) -> u32 {
+    let params = make_params(
+        creator.clone(),
+        String::from_str(env, "Campaign"),
+        String::from_str(env, "Description"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0,
+    );
+    client.create_campaign(&params)
+}
+
+#[test]
+fn test_censure_comment_sets_flag_and_emits_event() {
+    let (env, admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+    let campaign_id = create_campaign(&env, &creator, &client);
+    let comment_hash = BytesN::from_array(&env, &[7u8; 32]);
+
+    assert!(!client.is_comment_censured(&campaign_id, &comment_hash));
+
+    client.censure_comment(&admin, &campaign_id, &comment_hash);
+
+    assert!(client.is_comment_censured(&campaign_id, &comment_hash));
+
+    let last_event = env.events().all().last().unwrap();
+    let expected_topics = (
+        String::from_str(&env, "comment_censured"),
+        campaign_id,
+        admin.clone(),
+    )
+        .into_val(&env);
+    assert_eq!(last_event.1, expected_topics);
+    let data: BytesN<32> = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(data, comment_hash);
+}
+
+#[test]
+fn test_censure_comment_non_admin_fails() {
+    let (env, _admin, creator, contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+    let campaign_id = create_campaign(&env, &creator, &client);
+    let comment_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    let result = client.try_censure_comment(&contributor1, &campaign_id, &comment_hash);
+    assert_eq!(result.unwrap_err().unwrap(), Error::NotAuthorized);
+    assert!(!client.is_comment_censured(&campaign_id, &comment_hash));
+}
+
+#[test]
+fn test_censure_comment_missing_campaign_fails() {
+    let (env, admin, _creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+    let comment_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    let result = client.try_censure_comment(&admin, &999, &comment_hash);
+    assert_eq!(result.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_censure_comment_twice_fails() {
+    let (env, admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+    let campaign_id = create_campaign(&env, &creator, &client);
+    let comment_hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.censure_comment(&admin, &campaign_id, &comment_hash);
+    let result = client.try_censure_comment(&admin, &campaign_id, &comment_hash);
+    assert_eq!(result.unwrap_err().unwrap(), Error::ValidationFailed);
+    assert!(client.is_comment_censured(&campaign_id, &comment_hash));
+}
+
+#[test]
+fn test_comment_censure_is_scoped_per_campaign_and_hash() {
+    let (env, admin, creator, _contributor1, _contributor2, _token, _token_admin, client) =
+        setup_env();
+    let campaign_a = create_campaign(&env, &creator, &client);
+    let campaign_b = create_campaign(&env, &creator, &client);
+    let hash_a = BytesN::from_array(&env, &[4u8; 32]);
+    let hash_b = BytesN::from_array(&env, &[5u8; 32]);
+
+    client.censure_comment(&admin, &campaign_a, &hash_a);
+
+    assert!(client.is_comment_censured(&campaign_a, &hash_a));
+    assert!(!client.is_comment_censured(&campaign_a, &hash_b));
+    assert!(!client.is_comment_censured(&campaign_b, &hash_a));
+}


### PR DESCRIPTION
## What
Adds the on-chain comment censure flag: DataKey::CommentCensured(campaign_id, comment_hash), an admin-only censure entry point that emits an event, and a getter the frontend checks before displaying comments. At minimum the censure is now on-chain and immutable evidence. CHANGELOG entry added per CONTRIBUTING.

## Testing
cargo fmt, clippy, check and the wasm32 release build (the CI build step) all pass on this branch. cargo test --features testutils does not compile on main currently; verified pre-existing and unrelated.

Closes #542
