### PR TITLE
refactor: named constants, persistent_set macro, unified param ordering, error Display annotations

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -177,8 +177,8 @@ pub(crate) fn update_platform_fee(env: &Env, new_fee: u32) -> Result<(), Error> 
 
 pub(crate) fn set_campaign_fee_override(
     env: &Env,
-    admin: Address,
     campaign_id: u32,
+    admin: Address,
     fee_bps: u32,
 ) -> Result<(), Error> {
     assert_admin(env, &admin)?;

--- a/src/campaigns/withdraw.rs
+++ b/src/campaigns/withdraw.rs
@@ -46,17 +46,17 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
     let fee_amount = campaign
         .amount_raised
         .checked_mul(platform_fee as i128)
-        .and_then(|n| n.checked_add(9999))
+        .and_then(|n| n.checked_add(crate::BPS_CEIL_OFFSET))
         .ok_or(Error::Overflow)?
-        / 10000;
+        / crate::BPS_DENOMINATOR as i128;
     let total_after_fee = campaign.amount_raised - fee_amount;
 
     let reserve_bps = get_withdraw_reserve_percentage(env);
     let reserve_amount = total_after_fee
         .checked_mul(reserve_bps as i128)
-        .and_then(|n| n.checked_add(9999))
+        .and_then(|n| n.checked_add(crate::BPS_CEIL_OFFSET))
         .ok_or(Error::Overflow)?
-        / 10000;
+        / crate::BPS_DENOMINATOR as i128;
     let creator_amount = total_after_fee - reserve_amount;
 
     // Execute token transfers BEFORE marking campaign as withdrawn to prevent stuck state
@@ -162,7 +162,7 @@ pub(crate) fn set_vesting_params(
 ) -> Result<(), Error> {
     crate::lifecycle::assert_admin(env, &admin)?;
     require_not_paused(env)?;
-    if reserve_bps > 10000 || delay_days > 365 {
+    if reserve_bps > crate::BPS_DENOMINATOR || delay_days > 365 {
         return Err(Error::ValidationFailed);
     }
     if delay_days == 0 && reserve_bps > 0 {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,17 @@
+//! Named constants shared across the contract.
+//!
+//! Hoisted here so magic numbers (`9999`, `10000`, `86400`) appear exactly
+//! once in the codebase (#482).
+
+/// Basis-point denominator: 10_000 bps == 100%.
+pub(crate) const BPS_DENOMINATOR: u32 = 10_000;
+
+/// Offset added to a numerator before dividing by [`BPS_DENOMINATOR`] to
+/// achieve ceiling division: `ceil(a / b) == (a + b - 1) / b`.
+pub(crate) const BPS_CEIL_OFFSET: i128 = BPS_DENOMINATOR as i128 - 1;
+
+/// Number of seconds in one day.
+pub(crate) const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Delay before a proposed token update can be accepted (7 days).
+pub(crate) const TOKEN_UPDATE_DELAY_SECS: u64 = 7 * SECONDS_PER_DAY;

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -66,7 +66,9 @@ pub(crate) fn contribute(
 
     // Fix #408: use checked arithmetic to avoid panic on overflow.
     // A huge contribution (> 200% of goal) triggers an auto-pause.
-    let amount_bps = amount.checked_mul(10000).ok_or(Error::Overflow)?;
+    let amount_bps = amount
+        .checked_mul(crate::BPS_DENOMINATOR as i128)
+        .ok_or(Error::Overflow)?;
     let threshold = campaign
         .funding_goal
         .checked_mul(crate::AUTO_PAUSE_SINGLE_CONTRIBUTION_BPS_THRESHOLD)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -90,3 +90,80 @@ pub enum Error {
     /// Cancellation is not allowed after the funding goal has been reached and funds have not yet been withdrawn.
     GoalMetCancellationNotAllowed = 42,
 }
+
+impl Error {
+    /// Returns the canonical string name of this error variant, so event
+    /// payloads and debug logs can show a human-readable name instead of the
+    /// bare discriminant number.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Error::NotAuthorized => "NotAuthorized",
+            Error::CampaignNotFound => "CampaignNotFound",
+            Error::CampaignNotActive => "CampaignNotActive",
+            Error::FundingGoalMustBePositive => "FundingGoalMustBePositive",
+            Error::InvalidDuration => "InvalidDuration",
+            Error::InvalidRevenueShare => "InvalidRevenueShare",
+            Error::RevenueShareOnlyForStartup => "RevenueShareOnlyForStartup",
+            Error::DeadlinePassed => "DeadlinePassed",
+            Error::ContributionMustBePositive => "ContributionMustBePositive",
+            Error::DeadlineNotPassed => "DeadlineNotPassed",
+            Error::FundsAlreadyWithdrawn => "FundsAlreadyWithdrawn",
+            Error::FundingGoalNotReached => "FundingGoalNotReached",
+            Error::NoFundsToWithdraw => "NoFundsToWithdraw",
+            Error::CampaignAlreadyVerified => "CampaignAlreadyVerified",
+            Error::ValidationFailed => "ValidationFailed",
+            Error::AlreadyVoted => "AlreadyVoted",
+            Error::NotTokenHolder => "NotTokenHolder",
+            Error::VotingQuorumNotMet => "VotingQuorumNotMet",
+            Error::VotingThresholdNotMet => "VotingThresholdNotMet",
+            Error::AlreadyInitialized => "AlreadyInitialized",
+            Error::NotPendingOwner => "NotPendingOwner",
+            Error::NoTransferPending => "NoTransferPending",
+            Error::InvalidNewOwner => "InvalidNewOwner",
+            Error::ContractPaused => "ContractPaused",
+            Error::ContributionCapExceeded => "ContributionCapExceeded",
+            Error::CampaignNotVerified => "CampaignNotVerified",
+            Error::AmountRaisedIsZero => "AmountRaisedIsZero",
+            Error::RevenueSharingNotEnabled => "RevenueSharingNotEnabled",
+            Error::CancellationNotAllowed => "CancellationNotAllowed",
+            Error::Overflow => "Overflow",
+            Error::InvalidTokenContract => "InvalidTokenContract",
+            Error::CreationDisabled => "CreationDisabled",
+            Error::FundingGoalTooLow => "FundingGoalTooLow",
+            Error::AdminVerificationConflict => "AdminVerificationConflict",
+            Error::CommunityVerificationConflict => "CommunityVerificationConflict",
+            Error::DeadlineAlreadyExtended => "DeadlineAlreadyExtended",
+            Error::ExtensionTooLong => "ExtensionTooLong",
+            Error::FundingGoalTooHigh => "FundingGoalTooHigh",
+            Error::InvalidPlatformFee => "InvalidPlatformFee",
+            Error::TransferAlreadyPending => "TransferAlreadyPending",
+            Error::InvalidVestingDelay => "InvalidVestingDelay",
+            Error::GoalMetCancellationNotAllowed => "GoalMetCancellationNotAllowed",
+        }
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use std::string::ToString;
+
+    use super::Error;
+
+    #[test]
+    fn display_matches_variant_name() {
+        assert_eq!(Error::NotAuthorized.to_string(), "NotAuthorized");
+        assert_eq!(Error::CampaignNotFound.name(), "CampaignNotFound");
+        assert_eq!(Error::Overflow.to_string(), "Overflow");
+        assert_eq!(
+            Error::GoalMetCancellationNotAllowed.to_string(),
+            "GoalMetCancellationNotAllowed"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,16 +15,15 @@ pub(crate) const CAMPAIGN_EXTENSION_MAX_DAYS: u64 = 365;
 pub(crate) const CAMPAIGN_FUNDING_GOAL_MIN: i128 = 100_000;
 pub(crate) const CAMPAIGN_FUNDING_GOAL_MAX: i128 = 1_000_000_000_000_000; // 10^15
 pub(crate) const PLATFORM_FEE_MAX_BPS: u32 = 1000; // 10%
-pub(crate) const PLATFORM_FEE_ABSOLUTE_MAX_BPS: u32 = 10000; // 100% — hard limit, basis-point formula requires fee <= 10000
+pub(crate) const PLATFORM_FEE_ABSOLUTE_MAX_BPS: u32 = BPS_DENOMINATOR; // 100% — hard limit, basis-point formula requires fee <= BPS_DENOMINATOR
 pub(crate) const REVENUE_SHARE_MAX_BPS: u32 = 5000; // 50%
 pub(crate) const AUTO_PAUSE_SINGLE_CONTRIBUTION_BPS_THRESHOLD: i128 = 20000;
 pub(crate) const AUTO_PAUSE_BURST_THRESHOLD: u32 = 10;
 pub(crate) const LIST_MAX_LIMIT: u32 = 50;
-pub(crate) const SECONDS_PER_DAY: u64 = 86_400;
-pub(crate) const TOKEN_UPDATE_DELAY_SECS: u64 = 7 * SECONDS_PER_DAY;
 
 mod admin;
 mod campaigns;
+mod constants;
 mod contributions;
 mod errors;
 mod lifecycle;
@@ -34,6 +33,9 @@ mod storage;
 mod types;
 mod voting;
 
+pub(crate) use constants::{
+    BPS_CEIL_OFFSET, BPS_DENOMINATOR, SECONDS_PER_DAY, TOKEN_UPDATE_DELAY_SECS,
+};
 pub use errors::Error;
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
 use storage::*;
@@ -281,11 +283,11 @@ impl ProofOfHeart {
 
     pub fn set_campaign_fee_override(
         env: Env,
-        admin: Address,
         campaign_id: u32,
+        admin: Address,
         fee_bps: u32,
     ) -> Result<(), Error> {
-        admin::set_campaign_fee_override(&env, admin, campaign_id, fee_bps)
+        admin::set_campaign_fee_override(&env, campaign_id, admin, fee_bps)
     }
 
     pub fn set_category_duration_cap(

--- a/src/revenue.rs
+++ b/src/revenue.rs
@@ -81,7 +81,7 @@ pub(crate) fn claim_revenue(
         .checked_mul(total_pool)
         .and_then(|n| n.checked_mul(campaign.revenue_share_percentage as i128))
         .and_then(|n| n.checked_div(campaign.effective_amount_raised))
-        .and_then(|n| n.checked_div(10000))
+        .and_then(|n| n.checked_div(crate::BPS_DENOMINATOR as i128))
         .ok_or(Error::Overflow)?;
     let already_claimed = get_revenue_claimed(env, campaign_id, &contributor);
     let claimable = total_due - already_claimed;
@@ -113,7 +113,7 @@ pub(crate) fn claim_creator_revenue(env: &Env, campaign_id: u32) -> Result<(), E
 
     require_revenue_sharing(&campaign, Error::ValidationFailed)?;
 
-    if campaign.revenue_share_percentage > 10000 {
+    if campaign.revenue_share_percentage > crate::BPS_DENOMINATOR {
         return Err(Error::ValidationFailed);
     }
 
@@ -121,10 +121,11 @@ pub(crate) fn claim_creator_revenue(env: &Env, campaign_id: u32) -> Result<(), E
     // Compute creator entitlement directly instead of as a residual from the
     // contributor pool. This avoids biasing creator payouts upward when
     // contributor-side division truncates (#386).
-    let creator_share_bps = 10000i128 - campaign.revenue_share_percentage as i128;
+    let creator_share_bps =
+        crate::BPS_DENOMINATOR as i128 - campaign.revenue_share_percentage as i128;
     let creator_share_total = total_pool
         .checked_mul(creator_share_bps)
-        .and_then(|n| n.checked_div(10000))
+        .and_then(|n| n.checked_div(crate::BPS_DENOMINATOR as i128))
         .ok_or(Error::Overflow)?;
 
     let already_claimed = get_creator_revenue_claimed(env, campaign_id);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,6 +7,18 @@ const BUMP_THRESHOLD: u32 = 7 * DAY_IN_LEDGERS;
 const BUMP_AMOUNT: u32 = 400 * DAY_IN_LEDGERS;
 pub const CATEGORY_CAMPAIGNS_BUCKET_SIZE: u32 = 500;
 
+/// Sets a persistent storage entry and extends its TTL in a single step,
+/// making it impossible to forget the TTL bump.
+macro_rules! persistent_set {
+    ($env:expr, $key:expr, $value:expr) => {{
+        let key = $key;
+        $env.storage().persistent().set(&key, $value);
+        $env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    }};
+}
+
 pub fn bump_instance_ttl(env: &Env) {
     env.storage()
         .instance()
@@ -157,11 +169,7 @@ pub fn get_campaign(env: &Env, campaign_id: u32) -> Option<Campaign> {
 
 /// Persists a campaign and extends its TTL.
 pub fn set_campaign(env: &Env, campaign_id: u32, campaign: &Campaign) {
-    let key = CampaignKey::Campaign(campaign_id);
-    env.storage().persistent().set(&key, campaign);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::Campaign(campaign_id), campaign);
 }
 
 pub fn get_campaign_start_time(env: &Env, campaign_id: u32) -> Option<u64> {
@@ -170,11 +178,7 @@ pub fn get_campaign_start_time(env: &Env, campaign_id: u32) -> Option<u64> {
 }
 
 pub fn set_campaign_start_time(env: &Env, campaign_id: u32, start_time: u64) {
-    let key = CampaignKey::CampaignStartTime(campaign_id);
-    env.storage().persistent().set(&key, &start_time);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CampaignStartTime(campaign_id), &start_time);
 }
 
 // ── Campaign count ────────────────────────────────────────────────────────────
@@ -296,11 +300,7 @@ pub fn get_contribution(env: &Env, campaign_id: u32, contributor: &Address) -> i
 
 /// Stores a contributor's contribution amount and extends its TTL.
 pub fn set_contribution(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
-    let key = ContributionKey::Contribution(campaign_id, contributor.clone());
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, ContributionKey::Contribution(campaign_id, contributor.clone()), &amount);
 }
 
 /// Returns a contributor's lifetime (non-decreasing) contribution to a campaign.
@@ -311,11 +311,7 @@ pub fn get_lifetime_contribution(env: &Env, campaign_id: u32, contributor: &Addr
 
 /// Stores a contributor's lifetime contribution amount and extends its TTL.
 pub fn set_lifetime_contribution(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
-    let key = ContributionKey::LifetimeContribution(campaign_id, contributor.clone());
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, ContributionKey::LifetimeContribution(campaign_id, contributor.clone()), &amount);
 }
 
 /// Removes a contributor's contribution record entirely.
@@ -339,11 +335,7 @@ pub fn get_contributor_count(env: &Env, campaign_id: u32) -> u32 {
 }
 
 pub fn set_contributor_count(env: &Env, campaign_id: u32, count: u32) {
-    let key = ContributionKey::ContributorCount(campaign_id);
-    env.storage().persistent().set(&key, &count);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, ContributionKey::ContributorCount(campaign_id), &count);
 }
 
 pub fn increment_contributor_count(env: &Env, campaign_id: u32) {
@@ -368,11 +360,7 @@ pub fn get_revenue_pool(env: &Env, campaign_id: u32) -> i128 {
 
 /// Stores the revenue pool balance for a campaign and extends its TTL.
 pub fn set_revenue_pool(env: &Env, campaign_id: u32, amount: i128) {
-    let key = RevenueKey::RevenuePool(campaign_id);
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, RevenueKey::RevenuePool(campaign_id), &amount);
 }
 
 /// Returns the revenue already claimed by a contributor.
@@ -383,11 +371,7 @@ pub fn get_revenue_claimed(env: &Env, campaign_id: u32, contributor: &Address) -
 
 /// Stores the revenue claimed amount for a contributor and extends its TTL.
 pub fn set_revenue_claimed(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
-    let key = RevenueKey::RevenueClaimed(campaign_id, contributor.clone());
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, RevenueKey::RevenueClaimed(campaign_id, contributor.clone()), &amount);
 }
 
 /// Removes the revenue claimed record for a contributor in a campaign.
@@ -404,11 +388,7 @@ pub fn get_creator_revenue_claimed(env: &Env, campaign_id: u32) -> i128 {
 
 /// Stores the creator's claimed revenue amount for a campaign and extends its TTL.
 pub fn set_creator_revenue_claimed(env: &Env, campaign_id: u32, amount: i128) {
-    let key = RevenueKey::CreatorRevenueClaimed(campaign_id);
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, RevenueKey::CreatorRevenueClaimed(campaign_id), &amount);
 }
 
 // ── Voting ────────────────────────────────────────────────────────────────────
@@ -421,11 +401,7 @@ pub fn get_approve_votes(env: &Env, campaign_id: u32) -> u32 {
 
 /// Stores the approval vote count for a campaign and extends its TTL.
 pub fn set_approve_votes(env: &Env, campaign_id: u32, count: u32) {
-    let key = VotingKey::ApproveVotes(campaign_id);
-    env.storage().persistent().set(&key, &count);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, VotingKey::ApproveVotes(campaign_id), &count);
 }
 
 /// Returns the number of rejection votes for a campaign.
@@ -436,11 +412,7 @@ pub fn get_reject_votes(env: &Env, campaign_id: u32) -> u32 {
 
 /// Stores the rejection vote count for a campaign and extends its TTL.
 pub fn set_reject_votes(env: &Env, campaign_id: u32, count: u32) {
-    let key = VotingKey::RejectVotes(campaign_id);
-    env.storage().persistent().set(&key, &count);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, VotingKey::RejectVotes(campaign_id), &count);
 }
 
 // ── Vote weights (token-weighted) ─────────────────────────────────────────────
@@ -453,11 +425,7 @@ pub fn get_approve_weight(env: &Env, campaign_id: u32) -> i128 {
 
 /// Stores the total approval token-weight for a campaign and extends its TTL.
 pub fn set_approve_weight(env: &Env, campaign_id: u32, weight: i128) {
-    let key = VotingKey::ApproveWeight(campaign_id);
-    env.storage().persistent().set(&key, &weight);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, VotingKey::ApproveWeight(campaign_id), &weight);
 }
 
 /// Returns the total rejection token-weight for a campaign.
@@ -468,11 +436,7 @@ pub fn get_reject_weight(env: &Env, campaign_id: u32) -> i128 {
 
 /// Stores the total rejection token-weight for a campaign and extends its TTL.
 pub fn set_reject_weight(env: &Env, campaign_id: u32, weight: i128) {
-    let key = VotingKey::RejectWeight(campaign_id);
-    env.storage().persistent().set(&key, &weight);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, VotingKey::RejectWeight(campaign_id), &weight);
 }
 
 /// Returns whether a voter has already voted on a campaign.
@@ -483,11 +447,7 @@ pub fn get_has_voted(env: &Env, campaign_id: u32, voter: &Address) -> bool {
 
 /// Records that a voter has voted on a campaign and extends the entry's TTL.
 pub fn set_has_voted(env: &Env, campaign_id: u32, voter: &Address) {
-    let key = VotingKey::HasVoted(campaign_id, voter.clone());
-    env.storage().persistent().set(&key, &true);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, VotingKey::HasVoted(campaign_id, voter.clone()), &true);
 }
 
 /// Removes the HasVoted record for a voter on a campaign.
@@ -580,11 +540,7 @@ pub fn get_category_campaigns(env: &Env, category: Category) -> Vec<u32> {
 /// Stores all campaign ids for a category and extends entry TTL.
 #[allow(dead_code)]
 pub fn set_category_campaigns(env: &Env, category: Category, ids: &Vec<u32>) {
-    let key = CampaignKey::CategoryCampaigns(category as u32);
-    env.storage().persistent().set(&key, ids);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CategoryCampaigns(category as u32), ids);
 }
 
 /// Returns the total number of campaigns in a category.
@@ -615,11 +571,7 @@ pub fn set_category_campaign_bucket(
     bucket_idx: u32,
     ids: &Vec<u32>,
 ) {
-    let key = CampaignKey::CategoryCampaignsBucket(category as u32, bucket_idx);
-    env.storage().persistent().set(&key, ids);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CategoryCampaignsBucket(category as u32, bucket_idx), ids);
 }
 
 // ── Version ───────────────────────────────────────────────────────────────────
@@ -675,11 +627,7 @@ pub fn get_creator_campaign_count(env: &Env, creator: &Address) -> u32 {
 
 /// Stores the total number of campaigns owned by a creator.
 pub fn set_creator_campaign_count(env: &Env, creator: &Address, count: u32) {
-    let key = CampaignKey::CreatorCampaignCount(creator.clone());
-    env.storage().persistent().set(&key, &count);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CreatorCampaignCount(creator.clone()), &count);
 }
 
 /// Returns the campaign IDs in a specific bucket for a creator.
@@ -707,11 +655,7 @@ pub fn set_creator_campaign_bucket(
     bucket_index: u32,
     ids: &soroban_sdk::Vec<u32>,
 ) {
-    let key = CampaignKey::CreatorCampaignsBucket(creator.clone(), bucket_index);
-    env.storage().persistent().set(&key, ids);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CreatorCampaignsBucket(creator.clone(), bucket_index), ids);
 }
 
 // ── Personal cap ─────────────────────────────────────────────────────────────
@@ -730,11 +674,7 @@ pub fn get_personal_cap(env: &Env, campaign_id: u32, contributor: &Address) -> O
 
 /// Stores a contributor's personal cap for a campaign and extends its TTL.
 pub fn set_personal_cap(env: &Env, campaign_id: u32, contributor: &Address, amount: i128) {
-    let key = ContributionKey::PersonalCap(campaign_id, contributor.clone());
-    env.storage().persistent().set(&key, &amount);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, ContributionKey::PersonalCap(campaign_id, contributor.clone()), &amount);
 }
 
 /// Removes a contributor's personal cap for a campaign.
@@ -819,11 +759,7 @@ pub fn get_campaign_reserve(env: &Env, campaign_id: u32) -> Option<CampaignReser
 }
 
 pub fn set_campaign_reserve(env: &Env, campaign_id: u32, reserve: &CampaignReserve) {
-    let key = CampaignKey::CampaignReserve(campaign_id);
-    env.storage().persistent().set(&key, reserve);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    persistent_set!(env, CampaignKey::CampaignReserve(campaign_id), reserve);
 }
 
 // ── Creation disabled flag ───────────────────────────────────────────────────

--- a/src/tests/test_admin.rs
+++ b/src/tests/test_admin.rs
@@ -625,7 +625,7 @@ fn test_campaign_fee_override_zero_percent() {
         0i128,
     ));
     client.verify_campaign(&campaign_id);
-    client.set_campaign_fee_override(&admin, &campaign_id, &0);
+    client.set_campaign_fee_override(&campaign_id, &admin, &0);
     client.contribute(&campaign_id, &contributor1, &1000);
     client.withdraw_funds(&campaign_id);
 
@@ -650,7 +650,7 @@ fn test_campaign_fee_override_custom_percent() {
         0i128,
     ));
     client.verify_campaign(&campaign_id);
-    client.set_campaign_fee_override(&admin, &campaign_id, &100);
+    client.set_campaign_fee_override(&campaign_id, &admin, &100);
     client.contribute(&campaign_id, &contributor1, &1000);
     client.withdraw_funds(&campaign_id);
 
@@ -696,9 +696,9 @@ fn test_campaign_fee_override_above_max_rejected() {
         0,
         0i128,
     ));
-    let res = client2.try_set_campaign_fee_override(&admin2, &id, &1001);
+    let res = client2.try_set_campaign_fee_override(&id, &admin2, &1001);
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
-    let res = client2.try_set_campaign_fee_override(&admin2, &id, &10001);
+    let res = client2.try_set_campaign_fee_override(&id, &admin2, &10001);
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
@@ -719,7 +719,7 @@ fn test_campaign_fee_override_non_admin_rejected() {
     ));
 
     let impostor = Address::generate(&env);
-    let res = client.try_set_campaign_fee_override(&impostor, &id, &0);
+    let res = client.try_set_campaign_fee_override(&id, &impostor, &0);
     assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
 }
 

--- a/src/tests/test_regressions.rs
+++ b/src/tests/test_regressions.rs
@@ -234,7 +234,7 @@ fn test_paused_admin_parameter_setting_functions_succeed() {
 
     client.pause();
 
-    let result_fee = client.try_set_campaign_fee_override(&admin, &campaign_id, &100u32);
+    let result_fee = client.try_set_campaign_fee_override(&campaign_id, &admin, &100u32);
     assert!(
         result_fee.is_ok(),
         "set_campaign_fee_override must succeed while paused"

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -35,7 +35,7 @@ pub fn set_params(
 ) -> Result<(), Error> {
     if min_votes_quorum == 0
         || min_votes_quorum > MAX_VOTES_QUORUM
-        || !(MIN_APPROVAL_THRESHOLD_BPS..=10000).contains(&approval_threshold_bps)
+        || !(MIN_APPROVAL_THRESHOLD_BPS..=crate::BPS_DENOMINATOR).contains(&approval_threshold_bps)
     {
         return Err(Error::ValidationFailed);
     }
@@ -176,7 +176,7 @@ pub fn verify_with_votes(env: &Env, campaign_id: u32) -> Result<(), Error> {
         // Use checked arithmetic to avoid silent overflow/truncation when
         // approve_weight is a large i128 (e.g. whale holders on 18-decimal tokens).
         approve_weight
-            .checked_mul(10000)
+            .checked_mul(crate::BPS_DENOMINATOR as i128)
             .and_then(|n| n.checked_div(total_weight))
             .unwrap_or(0) as u32
     } else {


### PR DESCRIPTION
## Summary

- **#482** — Hoisted the magic numbers `9999`, `10000`, and `86400` into named constants in a new `src/constants.rs` (`BPS_DENOMINATOR`, `BPS_CEIL_OFFSET`, `SECONDS_PER_DAY`, `TOKEN_UPDATE_DELAY_SECS`), replacing every inline literal in `withdraw.rs`, `revenue.rs`, `contributions.rs`, and `voting.rs`. `SECONDS_PER_DAY`/`TOKEN_UPDATE_DELAY_SECS` already existed in `lib.rs`; they were moved into `constants.rs` alongside the new BPS constants.
- **#484** — Added a `persistent_set!` macro in `src/storage.rs` that combines `env.storage().persistent().set(...)` with the matching `extend_ttl(...)` call in one step. Replaced all ~19 hand-written set+bump pairs in `storage.rs` with the macro so the TTL bump can no longer be forgotten. Rebased on top of #589's storage-key domain split (`AdminKey`/`CampaignKey`/`ContributionKey`/`VotingKey`/`RevenueKey`), so every macro call now uses the split key enums instead of the old flat `DataKey`.
- **#485** — Audited every public contract function for `campaign_id`/actor parameter ordering. Found one inconsistency: `set_campaign_fee_override(env, admin, campaign_id, fee_bps)` — reordered to `set_campaign_fee_override(env, campaign_id, admin, fee_bps)` to match the standard `(env, campaign_id, actor, ...)` convention used everywhere else. Updated the internal `admin::set_campaign_fee_override` helper and all call sites (contract entry point, and the fee-override tests, which now live in `test_admin.rs` after #589's test consolidation).
- **#486** — Added `Error::name()` (mapping each variant to its string name) and a `core::fmt::Display` impl for `Error` in `src/errors.rs`, so error values shown in logs/`to_string()` render as e.g. `"CampaignNotFound"` instead of just the raw discriminant. Added a unit test asserting `Display`/`name()` match variant names.

No behavior changes — these are refactors only. Public function signature changed for `set_campaign_fee_override` (#485); all call sites (contract entry point, internal helper, tests) were updated in this PR.

This branch was rebased onto `main` after #589 (storage-key split, test consolidation, fee-amount event hiding) landed. The rebase resolved conflicts in `storage.rs` by keeping #589's domain-split key enums and layering this PR's `persistent_set!` macro on top of them, and resolved a modify/delete conflict on `test_fee_override.rs` by applying the parameter-order fix directly to the equivalent tests in `test_admin.rs` (where #589 had already relocated them).

## Test plan

- [x] `cargo build` — compiles cleanly with no warnings introduced
- [x] `cargo test` — **280 passed, 0 failed**. The pre-existing compile failure this PR previously noted (stale `types::MaybeAddress`/`uses_milestones` references from #574) was fixed upstream by #589, so the full suite now runs and passes after this rebase.
- [x] Manually verified: `Error::Display`/`name()` output matches variant names via a unit test in `errors.rs`
- [x] Manually verified: no remaining inline `9999`/`10000`/`86400` literals outside `constants.rs` in non-test source
- [x] Manually verified: no remaining hand-written `set` + `extend_ttl` pairs in `storage.rs`

Closes #482
Closes #484
Closes #485
Closes #486
