### PR TITLE
feat: creator stats, no-init version getter, cap semantics docs, threat model

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -22,3 +22,61 @@ This is a **known limitation** of the current implementation. A robust fix would
 - **Monitoring**: Integration layers (frontends/indexers) should monitor for large token transfers between addresses that subsequently vote on the same campaign.
 - **Minimum Balance**: The `MinVotingBalance` setting helps increase the cost of creating multiple voting accounts but does not prevent the attack by a sufficiently capitalized entity.
 - **Future Improvements**: Future versions may explore integration with specialized governance tokens that support historical snapshots.
+
+## Withdrawals & Funds Management
+
+### Vesting Reserve Admin Power (#493)
+
+**Description**: `set_vesting_params` lets the admin set a withdrawal release delay (`delay_days`, up to 365) and a reserve percentage (`reserve_bps`, up to `BPS_DENOMINATOR`, i.e. up to 100%) that apply to every subsequent `withdraw_funds` call. Because these are global settings read at withdrawal time (not snapshotted per-campaign at creation), an admin can change them at any point, including to a maximally punitive combination (e.g. 365-day delay with a 99.99% reserve), and the new values immediately apply to campaigns that were created and funded under a more favorable — or no — vesting policy.
+
+**Attack Vector**:
+1. A campaign is created and funded to goal while `delay_days == 0` and `reserve_bps == 0` (vesting disabled).
+2. Before the creator calls `withdraw_funds`, the admin calls `set_vesting_params` with `delay_days = 365` and `reserve_bps` near `BPS_DENOMINATOR`.
+3. The creator withdraws and receives only a sliver of `total_after_fee` immediately; the remainder is locked in `CampaignReserve` for up to a year, with no per-campaign override.
+4. Even a creator who has already reached `funding_goal` has no way to "lock in" the vesting terms that were in effect when contributors backed the campaign.
+
+**Mitigation Status**:
+This is a **known limitation** of the current implementation. `set_vesting_params` is intentionally admin-gated (`assert_admin`) and rejects internally inconsistent values (`reserve_bps > BPS_DENOMINATOR`, `delay_days > 365`, or a nonzero reserve paired with a zero delay via `Error::InvalidVestingDelay`), but it does not, and currently cannot, protect a specific campaign's withdrawal terms from a later admin policy change, since vesting parameters are stored as a single global pair (`WithdrawReleaseDelayDays`, `WithdrawReservePercentage`) rather than snapshotted onto `Campaign` at creation time.
+
+**Risk Management**:
+- **Trust assumption**: The admin key is already a fully trusted role in this contract (it also controls `platform_fee`, `creation_disabled`, campaign verification, and pausing) — this is consistent with, not an escalation beyond, the existing admin trust model.
+- **Monitoring**: The `vesting_params_updated` / `vesting_disabled` events give integrators an on-chain signal to alert creators and contributors whenever the policy changes, so a sudden tightening ahead of expected withdrawals can be flagged.
+- **Future Improvements**: A future version could snapshot `delay_days`/`reserve_bps` onto each `Campaign` at creation (mirroring how `fee_override` already pins a per-campaign fee independent of the global `platform_fee`), so in-flight campaigns are unaffected by later global changes.
+
+## Contribution Caps
+
+### Personal Cap Self-DoS on Refund Path (#493)
+
+**Description**: `set_personal_cap` lets a contributor voluntarily lower their own per-campaign contribution ceiling (bounded above by `Campaign::max_contribution_per_user` when that field is nonzero). This cap is enforced on `contribute` but is not consulted by `claim_refund`, `claim_revenue`, or any withdrawal path — those only read the contributor's stored `Contribution`/`LifetimeContribution` amounts. A contributor cannot use `set_personal_cap` to block their own refunds or revenue claims; the cap only ever restricts future contributions.
+
+**Attack Vector (self-inflicted, not third-party)**:
+1. A contributor sets an unusually low personal cap (e.g. `0` or `1`) via `set_personal_cap` after already having contributed a larger amount.
+2. The contributor cannot "un-contribute" past funds — `set_personal_cap` only rejects *future* `contribute` calls above the new cap; it never rewrites `Contribution`/`LifetimeContribution`.
+3. If the campaign later fails or is cancelled, `claim_refund` still reads and refunds the full stored contribution amount, unaffected by the personal cap. Likewise `claim_revenue` computes payouts from `effective_amount_raised`/contribution share, not the personal cap.
+
+**Mitigation Status**:
+**Not a vulnerability** under the current design: `set_personal_cap` only gates the `check_contribution_caps` / personal-cap comparison inside `contribute` (`current + amount > cap`). `claim_refund` and revenue-claim paths never read `PersonalCap` storage, so there is no code path by which a contributor's own cap can lock up their own refund. This entry documents the boundary explicitly so future changes to the refund/revenue paths don't accidentally start consulting the personal cap and reintroduce a self-DoS.
+
+**Risk Management**:
+- **Invariant to preserve**: Refund (`claim_refund`) and revenue claim (`claim_revenue`) logic must never gate on `PersonalCap` — only on the actual recorded `Contribution` and `RevenueClaimed` amounts.
+- **Testing**: Regression tests should cover "contributor lowers their own personal cap after contributing, then successfully claims a full refund" to guard this invariant across future refactors.
+
+## Campaign Creation
+
+### Category Duration Cap Below Existing Deadlines (#493)
+
+**Description**: `set_category_duration_cap` lets the admin set a per-category maximum `duration_days` for *future* `create_campaign` calls (checked against `crate::CAMPAIGN_DURATION_MIN_DAYS..=duration_max` in `create_campaign`). This cap only constrains new campaigns at creation time — it is never re-checked against, or applied to, campaigns that already exist. An admin lowering a category's cap below the remaining time on already-active campaigns in that category does not shorten, invalidate, or otherwise affect those campaigns' `deadline` fields.
+
+**Attack Vector**:
+1. Category `Learner` has no explicit cap, so campaigns may run up to `CAMPAIGN_DURATION_MAX_DAYS` (365 days). A campaign is created with a 300-day duration; its `deadline` is fixed at creation via `calculate_deadline`.
+2. The admin later calls `set_category_duration_cap` for `Learner` with `max_days = 30`.
+3. The existing 300-day campaign's stored `deadline` is untouched — `Campaign.deadline` is only read, never recomputed against the current cap, by any lifecycle path (`require_active_campaign`, `contribute`, `withdraw_funds`, etc.).
+4. New campaigns in `Learner` are now limited to 30 days, while the old one continues accepting contributions on its original, longer schedule until its original deadline.
+
+**Mitigation Status**:
+This is **expected, non-breaking behavior**: applying a lowered cap retroactively would require unilaterally shortening a `deadline` that contributors relied on when deciding to fund the campaign, which would be a strictly worse outcome (a de facto un-consented early cutoff) than leaving existing campaigns on their original terms. The one-way check at creation time (`duration_max = get_category_duration_cap(...).unwrap_or(CAMPAIGN_DURATION_MAX_DAYS)`) is intentional.
+
+**Risk Management**:
+- **Documentation**: This entry exists so cap changes are understood as prospective-only; operators should not assume lowering a category cap affects campaigns already in flight.
+- **Monitoring**: The `category_duration_cap_set` / `category_duration_cap_removed` events let indexers flag the change and, if desired, surface a "grandfathered under a previous, longer cap" indicator on affected campaigns in a frontend.
+- **Future Improvements**: If retroactive shortening is ever desired (e.g. for abuse response), it should be a distinct, explicitly audited admin action — such as `force_shorten_deadline` — rather than an implicit side effect of `set_category_duration_cap`, to keep the two concerns (future policy vs. existing campaign state) separate.

--- a/src/campaigns/create.rs
+++ b/src/campaigns/create.rs
@@ -72,6 +72,9 @@ pub(crate) fn create_campaign(env: &Env, params: CreateCampaignParams) -> Result
     if has_revenue_sharing && revenue_share_percentage == 0 {
         return Err(Error::InvalidRevenueShare);
     }
+    // `0` is accepted and means "no per-user cap" (unlimited) — an explicit,
+    // documented sentinel, not "0 tokens allowed". Only negative values are
+    // rejected here (#530).
     if max_contribution_per_user < 0 {
         return Err(Error::ValidationFailed);
     }

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -13,6 +13,10 @@ use crate::storage::{
 };
 use crate::types::Campaign;
 
+/// `max_contribution_per_user == 0` is an explicit "no cap" sentinel, not
+/// "0 tokens allowed" — see the doc comment on `Campaign::max_contribution_per_user`
+/// (#530). `create_campaign` rejects negative values, so `0` and positive
+/// values are the only inputs the cap check needs to handle here.
 fn check_contribution_caps(
     campaign: &Campaign,
     current_lifetime_contribution: i128,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,14 @@ impl ProofOfHeart {
         get_version(&env)
     }
 
+    /// Returns the compiled-in contract version. Unlike `get_version`, this
+    /// reads a constant baked into the WASM at build time rather than
+    /// instance storage, so it can be called on a freshly deployed contract
+    /// before `init` has ever been invoked (#523).
+    pub fn contract_version(_env: Env) -> u32 {
+        CONTRACT_VERSION
+    }
+
     pub fn get_admin(env: Env) -> Address {
         get_admin(&env)
     }
@@ -532,6 +540,10 @@ impl ProofOfHeart {
 
     pub fn get_platform_stats(env: Env) -> PlatformStats {
         queries::get_platform_stats(&env)
+    }
+
+    pub fn get_creator_stats(env: Env, creator: Address) -> CreatorStats {
+        queries::get_creator_stats(&env, creator)
     }
 }
 

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -2,11 +2,11 @@ use soroban_sdk::{Address, Env};
 
 use crate::storage::{
     get_active_campaign_count, get_campaign, get_campaign_count, get_cancelled_campaign_count,
-    get_category_campaign_bucket, get_category_campaign_count, get_creator_campaign_bucket,
-    get_creator_campaign_count, get_total_raised_global, get_verified_campaign_count,
-    CATEGORY_CAMPAIGNS_BUCKET_SIZE, CREATOR_CAMPAIGNS_BUCKET_SIZE,
+    get_category_campaign_bucket, get_category_campaign_count, get_contributor_count,
+    get_creator_campaign_bucket, get_creator_campaign_count, get_total_raised_global,
+    get_verified_campaign_count, CATEGORY_CAMPAIGNS_BUCKET_SIZE, CREATOR_CAMPAIGNS_BUCKET_SIZE,
 };
-use crate::types::{Campaign, Category, PlatformStats};
+use crate::types::{Campaign, Category, CreatorStats, PlatformStats};
 
 pub(crate) fn list_campaigns(env: &Env, start: u32, limit: u32) -> soroban_sdk::Vec<Campaign> {
     let total_count = get_campaign_count(env);
@@ -152,6 +152,43 @@ pub(crate) fn get_creator_campaigns(
     }
 
     campaigns
+}
+
+/// Aggregates total raised, active campaign count, and total contributors
+/// across every campaign owned by `creator` (#519). Walks the creator's
+/// campaign buckets directly (same storage layout `get_creator_campaigns`
+/// paginates over) rather than the paginated query, since a creator's own
+/// campaign count is bounded by normal usage and the caller wants a
+/// complete aggregate, not a page.
+pub(crate) fn get_creator_stats(env: &Env, creator: Address) -> CreatorStats {
+    let total = get_creator_campaign_count(env, &creator);
+
+    let mut active_campaigns = 0u32;
+    let mut total_raised: i128 = 0;
+    let mut total_contributors: u32 = 0;
+
+    let num_buckets = total.div_ceil(CREATOR_CAMPAIGNS_BUCKET_SIZE);
+    for bucket_idx in 0..num_buckets {
+        let bucket = get_creator_campaign_bucket(env, &creator, bucket_idx);
+        for i in 0..bucket.len() {
+            if let Some(campaign_id) = bucket.get(i) {
+                if let Some(campaign) = get_campaign(env, campaign_id) {
+                    if campaign.is_active && !campaign.is_cancelled {
+                        active_campaigns += 1;
+                    }
+                    total_raised += campaign.amount_raised;
+                    total_contributors += get_contributor_count(env, campaign_id);
+                }
+            }
+        }
+    }
+
+    CreatorStats {
+        total_campaigns: total,
+        active_campaigns,
+        total_raised,
+        total_contributors,
+    }
 }
 
 pub(crate) fn get_platform_stats(env: &Env) -> PlatformStats {

--- a/src/tests/test_queries.rs
+++ b/src/tests/test_queries.rs
@@ -157,6 +157,72 @@ fn test_get_platform_stats_returns_aggregates() {
 }
 
 #[test]
+fn test_get_creator_stats_returns_aggregates() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+    token_admin.mint(&contributor1, &2_000);
+    token_admin.mint(&contributor2, &2_000);
+
+    let c1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Creator Stats 1"),
+        String::from_str(&env, "s1"),
+        500,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let c2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Creator Stats 2"),
+        String::from_str(&env, "s2"),
+        500,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    let _ = client.try_verify_campaign(&c1);
+    let _ = client.try_verify_campaign(&c2);
+    client.contribute(&c1, &contributor1, &400);
+    client.contribute(&c2, &contributor1, &100);
+    client.contribute(&c2, &contributor2, &200);
+    client.cancel_campaign(&c2);
+
+    let stats = client.get_creator_stats(&creator);
+    assert_eq!(stats.total_campaigns, 2);
+    assert_eq!(stats.active_campaigns, 1);
+    assert_eq!(stats.total_raised, 700);
+    assert_eq!(stats.total_contributors, 3);
+}
+
+#[test]
+fn test_get_creator_stats_empty_for_unknown_creator() {
+    let (_env, _admin, _creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+    let stranger = Address::generate(&_env);
+
+    let stats = client.get_creator_stats(&stranger);
+    assert_eq!(stats.total_campaigns, 0);
+    assert_eq!(stats.active_campaigns, 0);
+    assert_eq!(stats.total_raised, 0);
+    assert_eq!(stats.total_contributors, 0);
+}
+
+#[test]
+fn test_contract_version_readable_without_init() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    // No `init` call here — `contract_version` must not require it.
+    assert_eq!(client.contract_version(), 1);
+}
+
+#[test]
 fn test_total_raised_global_tracking() {
     let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
         setup_env();

--- a/src/types.rs
+++ b/src/types.rs
@@ -83,7 +83,13 @@ pub struct Campaign {
     pub has_revenue_sharing: bool,
     /// Percentage of deposited revenue distributed to contributors, in basis points.
     pub revenue_share_percentage: u32,
-    /// Maximum tokens a single contributor may contribute in total. 0 means no cap.
+    /// Maximum tokens a single contributor may contribute in total, in
+    /// lifetime-contribution terms. `0` is an explicit, intentional sentinel
+    /// meaning "no per-user cap" (unlimited) — it is not treated as "0 tokens
+    /// allowed" (#530). Negative values are rejected at creation
+    /// (`create_campaign`); frontends should send `0` (not omit the field)
+    /// when the creator wants no limit, and must not send `0` to mean "block
+    /// all contributions" — there is no such state for this field.
     pub max_contribution_per_user: i128,
     /// Per-campaign platform fee override in basis points. None = use global fee.
     pub fee_override: Option<u32>,
@@ -114,6 +120,23 @@ pub struct PlatformStats {
     pub scanned_up_to: u32,
 }
 
+/// Aggregate metrics for a single creator across all of their campaigns,
+/// used for creator-profile dashboards and indexer consumers (#519).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreatorStats {
+    /// Total campaigns ever created by this creator.
+    pub total_campaigns: u32,
+    /// Campaigns currently active and not cancelled.
+    pub active_campaigns: u32,
+    /// Sum of `amount_raised` across all of the creator's campaigns.
+    pub total_raised: i128,
+    /// Sum of per-campaign contributor counts across all of the creator's
+    /// campaigns. Note: a contributor who backs multiple campaigns by the
+    /// same creator is counted once per campaign, not once overall.
+    pub total_contributors: u32,
+}
+
 /// Parameters for `create_campaign`, grouped into a single struct to avoid
 /// positional-argument mistakes when calling via CLI or SDK.
 #[contracttype]
@@ -136,7 +159,10 @@ pub struct CreateCampaignParams {
     /// Contributor revenue share in basis points (1–5000). Ignored (stored as 0) when
     /// `has_revenue_sharing` is `false`.
     pub revenue_share_percentage: u32,
-    /// Per-user contribution cap in tokens. `0` means no cap.
+    /// Per-user contribution cap in tokens. `0` explicitly means "no cap"
+    /// (unlimited), matching `Campaign::max_contribution_per_user` (#530).
+    /// This is intentional, not a placeholder for "disabled" — negative
+    /// values are the only rejected input.
     pub max_contribution_per_user: i128,
 }
 


### PR DESCRIPTION
## Summary

- **#519** — Add `get_creator_stats(creator)` view aggregating `total_campaigns`, `active_campaigns`, `total_raised`, and `total_contributors` across all of a creator's campaigns, using the existing per-creator campaign buckets.
- **#523** — Add `contract_version()`, a pure getter that returns the compiled-in `CONTRACT_VERSION` constant directly (not via instance storage), so it is callable on a freshly deployed contract before `init` — unlike the existing `get_version()`, which reflects the storage-tracked migration version and defaults to `0` pre-init.
- **#530** — `max_contribution_per_user == 0` already meant "no cap" (unlimited) across the codebase and is relied on by dozens of existing tests, so behavior is unchanged. Clarified and centralized the documentation of this sentinel on `Campaign`, `CreateCampaignParams`, `create_campaign`'s validation, and `check_contribution_caps`, so the semantic is explicit and not mistaken for "0 tokens allowed" or a bug.
- **#493** — Added three new `docs/THREAT_MODEL.md` sections following the existing format (Description / Attack Vector / Mitigation Status / Risk Management): the vesting reserve being a global (not per-campaign) admin setting, why the personal cap cannot self-DoS a contributor's own refund path, and why lowering a category's duration cap is intentionally prospective-only.

## Test plan

- [x] `cargo test` — 283 passed, 0 failed (added tests for `get_creator_stats` aggregation, empty-creator case, and `contract_version` callable pre-init)
- [x] `cargo build --target wasm32-unknown-unknown --release` — builds clean
- [x] `cargo clippy --all-targets` — no warnings

Closes #493
Closes #519
Closes #523
Closes #530