### PR TITLE
Fix corrupted-campaign panic, revenue rounding dust, and add contribute() fuzz harness

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,28 @@
+name: Nightly Fuzz
+
+# Issue #506: `contribute()` moves user funds through several validation
+# paths, so it gets a dedicated fuzzing harness (fuzz/fuzz_targets/fuzz_contribute.rs).
+# Runs nightly on a time budget rather than on every push/PR, since fuzzing
+# is open-ended and not meant to gate merges.
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  fuzz-contribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+      - name: Fuzz contribute() for 60 seconds
+        run: cargo fuzz run fuzz_contribute -- -max_total_time=60
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-contribute-crashes
+          path: fuzz/artifacts/fuzz_contribute/
+          if-no-files-found: ignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,12 @@ edition = "2021"
 license = "MIT"
 
 [lib]
-crate-type = ["cdylib"]
+# `rlib` is added alongside `cdylib` so the crate can also be depended on as
+# an ordinary Rust library -- needed by the `fuzz/` cargo-fuzz harness (#506),
+# which links against this crate with the `testutils` feature enabled. This
+# has no effect on the `wasm32-unknown-unknown` contract build, which only
+# produces the `cdylib` artifact.
+crate-type = ["cdylib", "rlib"]
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "proof-of-heart-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+
+[dependencies.proof-of-heart]
+path = ".."
+features = ["testutils"]
+
+[patch.crates-io]
+# Same vendored ethnum patch as the parent crate (soroban-sdk 20.1.0 pins
+# ethnum 1.5.0, which fails to compile on Rust 1.80+). Kept in sync with the
+# `[patch.crates-io]` section in ../Cargo.toml.
+ethnum = { path = "../vendor/ethnum" }
+
+# Prevent this from interfering with workspace resolution of the library.
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_contribute"
+path = "fuzz_targets/fuzz_contribute.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_contribute.rs
+++ b/fuzz/fuzz_targets/fuzz_contribute.rs
@@ -1,0 +1,99 @@
+//! Fuzz target for `contribute()` (issue #506).
+//!
+//! `contribute` is the primary path through which user funds enter the
+//! contract, and it chains together several validation checks (paused,
+//! verified, active, deadline, personal/global caps, overflow-checked
+//! anomaly-detection thresholds) before touching storage or moving tokens.
+//! Property tests cover specific scenarios; this harness instead throws
+//! adversarial, arbitrary input at the same entry point to catch edge cases
+//! (extreme `i128` amounts, unusual campaign parameters, repeated calls)
+//! that hand-written cases miss.
+//!
+//! The property under test: `contribute` must never panic / trap the host,
+//! no matter the amount or campaign state -- it must always resolve to
+//! either `Ok(())` or a typed `Err(Error)`.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String};
+
+use proof_of_heart::{Category, CreateCampaignParams, ProofOfHeart, ProofOfHeartClient};
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    amount_hi: i64,
+    amount_lo: u64,
+    funding_goal_raw: u32,
+    duration_days_raw: u8,
+    mint_amount: u32,
+    platform_fee_raw: u16,
+    skip_verify: bool,
+    contribute_twice: bool,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let contributor = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = StellarAssetClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    // Platform fee must be within bounds accepted by `init`; anything else
+    // should be rejected gracefully, in which case there's nothing further
+    // to fuzz for this input.
+    let platform_fee = (input.platform_fee_raw as u32) % 1001;
+    if client.try_init(&admin, &token_address, &platform_fee).is_err() {
+        return;
+    }
+
+    let mint_amount = (input.mint_amount as i128).saturating_add(1);
+    token_admin.mint(&contributor, &mint_amount);
+
+    let funding_goal = (input.funding_goal_raw as i128).saturating_add(1);
+    let duration_days = (input.duration_days_raw as u64).saturating_add(1).min(365);
+
+    let params = CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Fuzz"),
+        description: String::from_str(&env, "Fuzz target campaign"),
+        funding_goal,
+        duration_days,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    };
+
+    let campaign_id = match client.try_create_campaign(&params) {
+        Ok(Ok(id)) => id,
+        _ => return,
+    };
+
+    if !input.skip_verify {
+        let _ = client.try_verify_campaign(&campaign_id);
+    }
+
+    // Combine two arbitrary integers into a wide i128 so both small and
+    // extreme (overflow-triggering) contribution amounts get exercised,
+    // including negative values and values near i128::MAX/MIN.
+    let amount = ((input.amount_hi as i128) << 64) | (input.amount_lo as i128);
+
+    // The call under test must never panic, regardless of amount or
+    // campaign state -- only `Ok(())` or a typed `Err(Error)` are allowed.
+    let _ = client.try_contribute(&campaign_id, &contributor, &amount);
+
+    if input.contribute_twice {
+        let _ = client.try_contribute(&campaign_id, &contributor, &amount);
+    }
+});

--- a/src/revenue.rs
+++ b/src/revenue.rs
@@ -6,8 +6,10 @@ use crate::lifecycle::{
     token_client,
 };
 use crate::storage::{
-    bump_instance_ttl, get_contribution, get_creator_revenue_claimed, get_revenue_claimed,
-    get_revenue_pool, get_token, set_creator_revenue_claimed, set_revenue_claimed,
+    bump_instance_ttl, get_contribution, get_contributor_count, get_contributor_revenue_claimants,
+    get_contributor_revenue_distributed, get_creator_revenue_claimed, get_revenue_claimed,
+    get_revenue_pool, get_token, set_contributor_revenue_claimants,
+    set_contributor_revenue_distributed, set_creator_revenue_claimed, set_revenue_claimed,
     set_revenue_pool,
 };
 
@@ -84,7 +86,39 @@ pub(crate) fn claim_revenue(
         .and_then(|n| n.checked_div(crate::BPS_DENOMINATOR as i128))
         .ok_or(Error::Overflow)?;
     let already_claimed = get_revenue_claimed(env, campaign_id, &contributor);
-    let claimable = total_due - already_claimed;
+    let mut claimable = total_due - already_claimed;
+
+    if claimable <= 0 {
+        return Err(Error::NoFundsToWithdraw);
+    }
+
+    // #526: integer division truncates each contributor's individual share,
+    // so the sum of every contributor's `claimable` can fall short of the
+    // full contributor-side pool, leaving dust stuck in the contract forever.
+    // Once every contributor entitled to this campaign has claimed at least
+    // once, give the last one to claim whatever remains of the
+    // contributor-side pool instead of their individually-truncated share,
+    // so the full allocation is paid out exactly.
+    let is_first_claim = already_claimed == 0;
+    let claimants_so_far = get_contributor_revenue_claimants(env, campaign_id);
+    let total_contributors = get_contributor_count(env, campaign_id);
+    let is_last_claimant =
+        is_first_claim && total_contributors > 0 && claimants_so_far + 1 >= total_contributors;
+
+    let distributed_so_far = get_contributor_revenue_distributed(env, campaign_id);
+    if is_last_claimant {
+        let creator_share_bps =
+            crate::BPS_DENOMINATOR as i128 - campaign.revenue_share_percentage as i128;
+        let creator_share_total = total_pool
+            .checked_mul(creator_share_bps)
+            .and_then(|n| n.checked_div(crate::BPS_DENOMINATOR as i128))
+            .ok_or(Error::Overflow)?;
+        let contributor_pool_total = total_pool - creator_share_total;
+        let pool_remaining = contributor_pool_total - distributed_so_far;
+        if pool_remaining > claimable {
+            claimable = pool_remaining;
+        }
+    }
 
     if claimable <= 0 {
         return Err(Error::NoFundsToWithdraw);
@@ -98,6 +132,14 @@ pub(crate) fn claim_revenue(
 
     // Update state only after successful external interaction
     set_revenue_claimed(env, campaign_id, &contributor, already_claimed + claimable);
+
+    // Track the running sum paid out to contributors, and the count of
+    // distinct contributors who have claimed at least once, so future claims
+    // can detect the last claimant (#526).
+    set_contributor_revenue_distributed(env, campaign_id, distributed_so_far + claimable);
+    if is_first_claim {
+        set_contributor_revenue_claimants(env, campaign_id, claimants_so_far + 1);
+    }
 
     env.events().publish(
         ("revenue_claimed", campaign_id, contributor.clone()),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env, Vec};
+use soroban_sdk::{contracttype, Address, Env, TryFromVal, Val, Vec};
 
 use crate::types::{Campaign, CampaignReserve, Category};
 
@@ -157,14 +157,31 @@ pub enum RevenueKey {
     RevenueClaimed(u32, Address),
     /// Revenue already claimed by the campaign creator, keyed by campaign ID.
     CreatorRevenueClaimed(u32),
+    /// Cumulative revenue already paid out to contributors from a campaign's
+    /// pool (running sum across every `claim_revenue` call), keyed by
+    /// campaign ID. Used to let the last unclaimed contributor absorb any
+    /// dust left over from per-contributor integer-division truncation
+    /// (#526).
+    ContributorRevenueDistributed(u32),
+    /// Number of distinct contributors who have claimed revenue at least
+    /// once for a campaign, keyed by campaign ID (#526).
+    ContributorRevenueClaimants(u32),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
 
 /// Returns the campaign for the given ID.
+///
+/// #528: reads the raw stored `Val` and converts it via `TryFromVal` instead
+/// of the SDK's `get::<K, Campaign>()`, which panics (traps the host) if the
+/// stored bytes fail to deserialize into `Campaign`. If the persistent key
+/// exists but its value is corrupted, this returns `None` instead of
+/// panicking, so callers can gracefully surface `Error::CampaignNotFound`
+/// rather than aborting the entire transaction.
 pub fn get_campaign(env: &Env, campaign_id: u32) -> Option<Campaign> {
     let key = CampaignKey::Campaign(campaign_id);
-    env.storage().persistent().get(&key)
+    let raw: Val = env.storage().persistent().get(&key)?;
+    Campaign::try_from_val(env, &raw).ok()
 }
 
 /// Persists a campaign and extends its TTL.
@@ -389,6 +406,40 @@ pub fn get_creator_revenue_claimed(env: &Env, campaign_id: u32) -> i128 {
 /// Stores the creator's claimed revenue amount for a campaign and extends its TTL.
 pub fn set_creator_revenue_claimed(env: &Env, campaign_id: u32, amount: i128) {
     persistent_set!(env, RevenueKey::CreatorRevenueClaimed(campaign_id), &amount);
+}
+
+/// Returns the cumulative amount already paid out to contributors from a
+/// campaign's revenue pool (#526).
+pub fn get_contributor_revenue_distributed(env: &Env, campaign_id: u32) -> i128 {
+    let key = RevenueKey::ContributorRevenueDistributed(campaign_id);
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+/// Stores the cumulative amount paid out to contributors from a campaign's
+/// revenue pool and extends its TTL.
+pub fn set_contributor_revenue_distributed(env: &Env, campaign_id: u32, amount: i128) {
+    persistent_set!(
+        env,
+        RevenueKey::ContributorRevenueDistributed(campaign_id),
+        &amount
+    );
+}
+
+/// Returns the number of distinct contributors who have claimed revenue at
+/// least once for a campaign (#526).
+pub fn get_contributor_revenue_claimants(env: &Env, campaign_id: u32) -> u32 {
+    let key = RevenueKey::ContributorRevenueClaimants(campaign_id);
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+/// Stores the number of distinct contributors who have claimed revenue at
+/// least once for a campaign and extends its TTL.
+pub fn set_contributor_revenue_claimants(env: &Env, campaign_id: u32, count: u32) {
+    persistent_set!(
+        env,
+        RevenueKey::ContributorRevenueClaimants(campaign_id),
+        &count
+    );
 }
 
 // ── Voting ────────────────────────────────────────────────────────────────────

--- a/src/tests/test_regressions.rs
+++ b/src/tests/test_regressions.rs
@@ -601,3 +601,80 @@ fn test_creator_claim_does_not_absorb_contributor_rounding() {
     // Previous residual math paid 5001 here; direct creator-side math must pay 5000.
     assert_eq!(creator_after - creator_before, 5_000);
 }
+
+// ── #526 last-claimant revenue dust ────────────────────────────────────────────
+
+/// Issue #526 — per-contributor integer division truncates each individual
+/// share, so the sum of every contributor's claim can fall short of the full
+/// contributor-side pool. The last contributor to claim must absorb that
+/// remainder instead of receiving their own individually-truncated share, so
+/// no revenue is permanently stuck in the contract.
+#[test]
+fn test_last_revenue_claimant_absorbs_rounding_dust() {
+    let (env, _admin, creator, contributor1, contributor2, token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &10);
+    token_admin.mint(&contributor2, &10);
+    token_admin.mint(&creator, &100);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Issue 526"),
+        description: String::from_str(&env, "Revenue dust regression"),
+        funding_goal: 3,
+        duration_days: 30,
+        category: Category::EducationalStartup,
+        has_revenue_sharing: true,
+        revenue_share_percentage: 5000, // 50%
+        max_contribution_per_user: 0i128,
+    });
+    client.verify_campaign(&campaign_id);
+
+    client.contribute(&campaign_id, &contributor1, &1);
+    client.contribute(&campaign_id, &contributor2, &2);
+    client.withdraw_funds(&campaign_id);
+    client.deposit_revenue(&campaign_id, &10);
+
+    // contributor_pool_total = 10 * 5000 / 10000 = 5.
+    // Naive per-contributor math: contributor1 = 1*10*5000/3/10000 = 1,
+    // contributor2 = 2*10*5000/3/10000 = 3 -> sum = 4, leaving 1 stuck.
+    let before1 = token.balance(&contributor1);
+    client.claim_revenue(&campaign_id, &contributor1);
+    let claimed1 = token.balance(&contributor1) - before1;
+    assert_eq!(claimed1, 1);
+
+    let before2 = token.balance(&contributor2);
+    client.claim_revenue(&campaign_id, &contributor2);
+    let claimed2 = token.balance(&contributor2) - before2;
+
+    // The last claimant (contributor2) must absorb the rounding dust, so the
+    // two contributor claims sum to exactly the contributor-side pool (5),
+    // not the naively-truncated 4.
+    assert_eq!(claimed1 + claimed2, 5);
+    assert_eq!(claimed2, 4);
+}
+
+// ── #528 corrupted campaign storage key ────────────────────────────────────────
+
+/// Issue #528 — if a campaign's persistent storage entry can't be
+/// deserialized into `Campaign`, `get_campaign` must return `None` (and
+/// therefore callers like `get_campaign_or_error` must surface
+/// `Error::CampaignNotFound`) instead of panicking / aborting the host.
+#[test]
+fn test_get_campaign_survives_corrupted_storage_entry() {
+    let (env, _admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&make_campaign_params_simple(&env, &creator));
+    assert!(client.get_campaign(&campaign_id).id == campaign_id);
+
+    // Corrupt the persistent entry backing this campaign by overwriting it
+    // with a value of a totally different (incompatible) shape.
+    env.as_contract(&client.address, || {
+        let key = CampaignKey::Campaign(campaign_id);
+        env.storage().persistent().set(&key, &"not a campaign");
+    });
+
+    let result = client.try_get_campaign(&campaign_id);
+    assert_eq!(result.unwrap_err().unwrap(), Error::CampaignNotFound);
+}

--- a/src/tests/test_revenue.rs
+++ b/src/tests/test_revenue.rs
@@ -99,8 +99,13 @@ fn test_revenue_sharing_edge_cases() {
     client.claim_revenue(&campaign_id, &contributor1);
     assert_eq!(token.balance(&contributor1), 10);
 
+    // #526: contributor2 is the last contributor to claim, so instead of
+    // their individually-truncated share (3, from 2*10*5000/3/10000), they
+    // absorb the remaining contributor-side pool (contributor_pool_total=5,
+    // minus the 1 already distributed to contributor1 = 4), so the full
+    // contributor allocation (5) is paid out exactly with no dust left over.
     client.claim_revenue(&campaign_id, &contributor2);
-    assert_eq!(token.balance(&contributor2), 11);
+    assert_eq!(token.balance(&contributor2), 12);
 
     let res = client.try_claim_revenue(&campaign_id, &contributor1);
     assert_eq!(res.unwrap_err().unwrap(), Error::NoFundsToWithdraw);


### PR DESCRIPTION
## Summary

- **#528** — `get_campaign` used the SDK's `get::<K, Campaign>()`, which panics (traps the host) if a persistent entry's bytes fail to deserialize into `Campaign`. It now reads the raw `Val` and converts it via `TryFromVal`, returning `None` on a failed conversion instead of panicking, so `get_campaign_or_error` (and every caller that goes through it) gracefully surfaces `Error::CampaignNotFound` instead of aborting the transaction.
- **#526** — `claim_revenue` computed each contributor's share via `contribution * total_pool * revenue_share_percentage / effective_amount_raised / BPS_DENOMINATOR`, and per-contributor integer-division truncation meant the sum of every contributor's claim could fall short of the full contributor-side pool, leaving dust stuck in the contract forever. A running "distributed so far" total and claimant count are now tracked per campaign; once every contributor entitled to the campaign has claimed at least once, the last one to claim absorbs whatever remains of the contributor-side pool instead of their own individually-truncated share, so the full allocation is paid out exactly. (`claim_creator_revenue`'s direct, non-residual math from #386 is left untouched, since reverting it to a residual calculation would reintroduce that exact bug.)
- **#511** — investigated and found already fixed: `get_lifetime_contribution` is backed by a `LifetimeContribution` storage key that is intentionally never decremented or removed on refund (`remove_lifetime_contribution` exists but is unused/`#[expect(dead_code)]`), and the personal-cap check in `contribute()` already reads from it rather than from the resettable `Contribution` key. This is covered by the existing `test_claim_refund_preserves_lifetime_contribution` regression test. No code change was needed for this issue.
- **#506** — added a `cargo-fuzz` harness (`fuzz/fuzz_targets/fuzz_contribute.rs`) targeting `contribute()`, feeding it arbitrary contribution amounts (including negative, zero, and overflow-inducing `i128` values near the type's bounds) and campaign setup variations (funding goal, duration, platform fee, verify-before-contribute, repeated calls). The property under test is that `contribute` always resolves to `Ok(())` or a typed `Err(Error)` and never panics. Added `.github/workflows/fuzz.yml` to run it nightly with a 60-second time budget via `workflow_dispatch`/`schedule`. The parent crate's `crate-type` gained `rlib` alongside `cdylib` so the fuzz crate can link against it with the `testutils` feature (no effect on the `wasm32-unknown-unknown` contract build).

## Test plan

- [x] `cargo test --features testutils` — 282 passed, 0 failed
- [x] `cargo clippy --all-targets --features testutils -- -D warnings` — clean
- [x] `cargo build --target wasm32-unknown-unknown --release` — succeeds
- [x] Added `test_get_campaign_survives_corrupted_storage_entry` (#528) — overwrites a campaign's persistent entry with an incompatible value and asserts `try_get_campaign` returns `Error::CampaignNotFound` instead of panicking
- [x] Added `test_last_revenue_claimant_absorbs_rounding_dust` (#526) — 2 contributors split a revenue pool where naive per-contributor truncation would strand 1 unit of dust; asserts the last claimant's payout absorbs it so total contributor claims equal the full contributor-side pool
- [ ] `cargo fuzz build` / `cargo fuzz run fuzz_contribute` — **not runnable in this environment** (`cargo-fuzz` isn't installable here, and it requires a nightly toolchain + libFuzzer/ASan support). The harness code and the nightly CI workflow entry are in place and were reviewed for correctness, but local execution of the fuzz binary itself was not verified. The CI workflow (`.github/workflows/fuzz.yml`) will exercise it nightly on `ubuntu-latest` with `dtolnay/rust-toolchain@nightly`.

Closes #528
Closes #526
Closes #511
Closes #506