### PR TITLE
Document security disclosure policy; verify funding-goal, transfer, and CI fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,33 @@ Please include the following in your report:
 - **Resolution:** We aim to resolve critical vulnerabilities within **7 days** and non-critical issues within **30 days**.
 - **Credit:** With your permission, we will credit you in the release notes once the vulnerability is fixed.
 
+### Severity Definitions
+
+We triage reports using the following severity levels:
+
+| Severity | Definition | Example |
+|----------|------------|---------|
+| **P0 — Critical** | Direct loss or theft of funds, permanent freezing of funds, or a way to bypass admin/auth controls. Can be exploited without special privileges. | Draining escrowed contributions, minting unauthorised withdrawals, admin impersonation. |
+| **P1 — High** | Significant contract malfunction that does not directly move funds but breaks a core invariant (e.g. accounting, voting, campaign lifecycle) or can be chained into a P0. | Incorrect fee/revenue-share accounting, vote-count manipulation, denial of service on a core entrypoint. |
+| **P2 — Medium/Low** | Limited-impact bugs, edge cases, or hardening opportunities that do not put funds or contract integrity at immediate risk. | Missing input validation with no exploitable consequence, gas/resource inefficiencies, informational issues. |
+
+### Responsible Disclosure Timeline
+
+We ask reporters to follow **coordinated disclosure**:
+
+1. Report the issue privately via the email above — do not open a public issue, PR, or forum post describing the vulnerability.
+2. We will work with you to validate, reproduce, and fix the issue.
+3. We request **90 days** from the initial report before any public disclosure, to give us time to ship and deploy a fix. This window can be shortened by mutual agreement (e.g. once a fix is live and users have had time to upgrade) or extended if the fix requires unusual coordination (e.g. a contract migration).
+4. If 90 days pass without a resolution or agreed extension, the reporter may disclose publicly, but we ask that you still coordinate the exact timing and content with us where possible.
+
+### Bug Bounty
+
+There is currently **no formal bug bounty program** for ProofOfHeart-stellar. Valid reports are eligible for credit in release notes (with your permission) but not monetary reward at this time. This section will be updated if a bounty program is established.
+
+### Audits
+
+No formal third-party security audit has been conducted on this contract to date, and no audit reports are available for publication. Given the contract handles escrowed funds, we recommend treating it as **unaudited** and exercising appropriate caution (e.g. capped deployments, monitoring) until an audit is completed. This section will be updated with links to any future audit reports.
+
 ### Scope
 
 This policy covers the on-chain Soroban smart contract (`src/`) and any official tooling in this repository. Frontend integrations or third-party services built on top of the contract are out of scope unless the vulnerability originates from the contract itself.


### PR DESCRIPTION
- **#521 (minimum funding goal):** verified already implemented — `min_campaign_funding_goal` is admin-configurable (default `CAMPAIGN_FUNDING_GOAL_MIN`), settable via `set_min_campaign_funding_goal_fn`, and enforced in `create_campaign` (`src/campaigns/create.rs`), rejecting goals below the configured minimum with `FundingGoalTooLow`.
- **#513 (pending transfer overwrite):** verified already implemented — `initiate_campaign_transfer` (`src/campaigns/transfer.rs`) checks `campaign.pending_creator.is_some()` and returns `Error::TransferAlreadyPending` before setting a new pending creator, so an in-flight transfer can no longer be silently overwritten. Covered by an existing regression test in `src/tests/test_campaigns.rs`.
- **#496 (SECURITY.md disclosure policy):** updated `SECURITY.md` to add a 90-day responsible disclosure timeline, P0/P1/P2 severity definitions, an explicit "no bug bounty program currently exists" statement, and an explicit "no formal audit has been conducted" statement.
- **#491 (CONTRIBUTING.md vs CI mismatch):** verified already resolved — `.github/workflows/ci.yml` runs dedicated `fmt` (`cargo fmt --all -- --check`) and `clippy` (`cargo clippy --all-targets --features testutils -- -D warnings`) jobs on every PR, matching what `CONTRIBUTING.md` documents. The referenced `IMPLEMENTATION_SUMMARY.md` no longer exists in the repo.

## Test plan

- [x] `cargo test --features testutils` — 285 passed, 0 failed
- [x] `cargo build --target wasm32-unknown-unknown --release` — builds successfully
- [x] `cargo clippy --all-targets --features testutils -- -D warnings` — no warnings
- [x] Manually reviewed `src/campaigns/create.rs` and `src/campaigns/transfer.rs` to confirm #521 and #513 behavior
- [x] Manually reviewed `.github/workflows/ci.yml` to confirm #491 behavior

Fixes #521
Fixes #513
Fixes #496
Fixes #491