### PR TITLE
feat: add campaign bookmarks, dependabot config, and deploy script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Tracks soroban-sdk (and other Cargo dependencies) so upgrades from the
+  # pinned 20.1.0 to current 22.x land as reviewable PRs instead of silently
+  # going stale (#499).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Keeps CI actions (actions/checkout, dtolnay/rust-toolchain, etc.) current.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 This guide covers deploying the ProofOfHeart smart contract on Stellar testnet and mainnet, from building the WASM to contract initialization and verification.
 
+> **Automated deploy:** `scripts/deploy.sh` scripts the build/deploy/init/verify steps below (#495). See [Scripted Deployment](#scripted-deployment) for usage, or read on for the full manual walkthrough.
+
 ## Table of Contents
 
 1. [Prerequisites & Setup](#prerequisites--setup)
@@ -561,6 +563,34 @@ soroban contract invoke --id "$CONTRACT_ID" --source deployer --network testnet 
 ```
 
 This clears the pending state with no effect on the current token.
+
+---
+
+## Scripted Deployment
+
+`scripts/deploy.sh` automates the manual steps above into four commands (#495):
+
+```bash
+# Build + deploy to testnet (prints CONTRACT_ID to export)
+scripts/deploy.sh deploy-testnet
+
+# Build + deploy to mainnet (uses SOURCE_ACCOUNT=deployer-mainnet)
+SOURCE_ACCOUNT=deployer-mainnet scripts/deploy.sh deploy-mainnet
+
+# Initialize a deployed contract
+CONTRACT_ID="C..." ADMIN_ADDRESS="G..." TOKEN_ADDRESS="C..." \
+  scripts/deploy.sh init --network testnet
+
+# Verify a deployed contract (contract info + contract_version)
+CONTRACT_ID="C..." scripts/deploy.sh verify --network testnet
+```
+
+Run `scripts/deploy.sh --help` for the full list of supported environment
+variables (`SOURCE_ACCOUNT`, `ADMIN_ADDRESS`, `TOKEN_ADDRESS`,
+`PLATFORM_FEE`, `CONTRACT_ID`). The script wraps the same `stellar` CLI
+commands documented in the sections above — it doesn't do anything the
+manual steps don't, it just sequences them and fails fast with a clear
+error message on missing prerequisites.
 
 ---
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# Automates the manual deployment steps documented in docs/DEPLOYMENT.md
+# (#495): build, deploy, init, and verify the ProofOfHeart Soroban contract
+# on testnet or mainnet.
+#
+# Usage:
+#   scripts/deploy.sh <command> [options]
+#
+# Commands:
+#   deploy-testnet    Build (if needed) and deploy the contract to testnet.
+#   deploy-mainnet    Build (if needed) and deploy the contract to mainnet.
+#   init              Initialize a deployed contract (admin/token/fee).
+#   verify            Verify a deployed contract is live and initialized.
+#
+# Environment variables:
+#   SOURCE_ACCOUNT   Stellar CLI identity to sign with (default: deployer).
+#   ADMIN_ADDRESS    Admin address to pass to `init`.
+#   TOKEN_ADDRESS    Token contract address to pass to `init`.
+#   PLATFORM_FEE     Platform fee in basis points for `init` (default: 300).
+#   CONTRACT_ID      Contract ID to target for `init`/`verify`.
+#
+# Examples:
+#   scripts/deploy.sh deploy-testnet
+#   SOURCE_ACCOUNT=deployer-mainnet scripts/deploy.sh deploy-mainnet
+#   CONTRACT_ID=C... ADMIN_ADDRESS=G... TOKEN_ADDRESS=C... scripts/deploy.sh init --network testnet
+#   CONTRACT_ID=C... scripts/deploy.sh verify --network testnet
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WASM_PATH="${REPO_ROOT}/target/wasm32-unknown-unknown/release/proof_of_heart.wasm"
+
+DEFAULT_PLATFORM_FEE=300
+
+log() {
+  printf '==> %s\n' "$1"
+}
+
+fail() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "'$1' is not installed or not on PATH."
+}
+
+build_contract() {
+  require_cmd cargo
+  log "Building contract WASM (cargo build --target wasm32-unknown-unknown --release)"
+  (cd "${REPO_ROOT}" && cargo build --target wasm32-unknown-unknown --release)
+
+  [ -f "${WASM_PATH}" ] || fail "Build finished but WASM not found at ${WASM_PATH}"
+  log "WASM built: ${WASM_PATH}"
+}
+
+deploy_to_network() {
+  local network="$1"
+  local source_account="${SOURCE_ACCOUNT:-deployer}"
+
+  require_cmd stellar
+  build_contract
+
+  log "Deploying to ${network} using source account '${source_account}'"
+  local contract_id
+  contract_id="$(stellar contract deploy \
+    --wasm "${WASM_PATH}" \
+    --source "${source_account}" \
+    --network "${network}")"
+
+  log "Deployed. Contract ID: ${contract_id}"
+  printf 'export CONTRACT_ID="%s"\n' "${contract_id}"
+}
+
+cmd_deploy_testnet() {
+  deploy_to_network "testnet"
+}
+
+cmd_deploy_mainnet() {
+  deploy_to_network "mainnet"
+}
+
+cmd_init() {
+  local network="testnet"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --network)
+        network="$2"
+        shift 2
+        ;;
+      *)
+        fail "Unknown option '$1' for 'init'"
+        ;;
+    esac
+  done
+
+  require_cmd stellar
+  [ -n "${CONTRACT_ID:-}" ] || fail "CONTRACT_ID is required (export CONTRACT_ID=\"C...\")"
+  [ -n "${ADMIN_ADDRESS:-}" ] || fail "ADMIN_ADDRESS is required"
+  [ -n "${TOKEN_ADDRESS:-}" ] || fail "TOKEN_ADDRESS is required"
+  local source_account="${SOURCE_ACCOUNT:-deployer}"
+  local platform_fee="${PLATFORM_FEE:-${DEFAULT_PLATFORM_FEE}}"
+
+  log "Initializing contract ${CONTRACT_ID} on ${network} (fee=${platform_fee}bps)"
+  stellar contract invoke \
+    --id "${CONTRACT_ID}" \
+    --source "${source_account}" \
+    --network "${network}" \
+    -- \
+    init \
+    --admin "${ADMIN_ADDRESS}" \
+    --token "${TOKEN_ADDRESS}" \
+    --platform_fee "${platform_fee}"
+
+  log "Initialization complete."
+}
+
+cmd_verify() {
+  local network="testnet"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --network)
+        network="$2"
+        shift 2
+        ;;
+      *)
+        fail "Unknown option '$1' for 'verify'"
+        ;;
+    esac
+  done
+
+  require_cmd stellar
+  [ -n "${CONTRACT_ID:-}" ] || fail "CONTRACT_ID is required (export CONTRACT_ID=\"C...\")"
+  local source_account="${SOURCE_ACCOUNT:-deployer}"
+
+  log "Checking contract info for ${CONTRACT_ID} on ${network}"
+  stellar contract info --id "${CONTRACT_ID}" --network "${network}"
+
+  log "Reading contract_version() for ${CONTRACT_ID} on ${network}"
+  stellar contract invoke \
+    --id "${CONTRACT_ID}" \
+    --source "${source_account}" \
+    --network "${network}" \
+    --is-read-only \
+    -- \
+    contract_version
+
+  log "Verification complete."
+}
+
+usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+  local command="${1:-}"
+  [ -n "${command}" ] || { usage; exit 1; }
+  shift || true
+
+  case "${command}" in
+    deploy-testnet) cmd_deploy_testnet "$@" ;;
+    deploy-mainnet) cmd_deploy_mainnet "$@" ;;
+    init) cmd_init "$@" ;;
+    verify) cmd_verify "$@" ;;
+    -h|--help|help) usage ;;
+    *) fail "Unknown command '${command}'. Run '$0 --help' for usage." ;;
+  esac
+}
+
+main "$@"

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -1,0 +1,69 @@
+//! On-chain campaign bookmark / save list for wallets (#507).
+//!
+//! Lets a wallet track causes it cares about without relying on the
+//! frontend: `save_campaign`, `remove_saved_campaign`, and
+//! `get_saved_campaigns` are plain ledger reads/writes keyed by the wallet
+//! address, so any client can display a user's saved campaigns directly from
+//! chain state.
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::errors::Error;
+use crate::lifecycle::get_campaign_or_error;
+use crate::storage::{get_saved_campaigns, set_saved_campaigns};
+
+/// Adds `campaign_id` to `user`'s saved-campaigns list.
+///
+/// Requires the wallet's authorization. Fails if the campaign doesn't exist
+/// or is already bookmarked.
+pub fn save_campaign(env: &Env, user: Address, campaign_id: u32) -> Result<(), Error> {
+    user.require_auth();
+
+    // Ensure the campaign actually exists before letting it be bookmarked.
+    get_campaign_or_error(env, campaign_id)?;
+
+    let mut saved = get_saved_campaigns(env, &user);
+    if saved.iter().any(|id| id == campaign_id) {
+        return Err(Error::CampaignAlreadyBookmarked);
+    }
+
+    saved.push_back(campaign_id);
+    set_saved_campaigns(env, &user, &saved);
+
+    env.events()
+        .publish(("campaign_bookmarked", user), campaign_id);
+
+    Ok(())
+}
+
+/// Removes `campaign_id` from `user`'s saved-campaigns list.
+///
+/// Requires the wallet's authorization. Fails if the campaign isn't
+/// currently bookmarked.
+pub fn remove_saved_campaign(env: &Env, user: Address, campaign_id: u32) -> Result<(), Error> {
+    user.require_auth();
+
+    let saved = get_saved_campaigns(env, &user);
+    let position = saved.iter().position(|id| id == campaign_id);
+
+    match position {
+        Some(idx) => {
+            let mut updated = saved;
+            updated.remove(idx as u32);
+            set_saved_campaigns(env, &user, &updated);
+
+            env.events()
+                .publish(("campaign_unbookmarked", user), campaign_id);
+
+            Ok(())
+        }
+        None => Err(Error::CampaignNotBookmarked),
+    }
+}
+
+/// Returns the list of campaign ids `user` has bookmarked, in the order they
+/// were saved. This is a public, unauthenticated read — any wallet/app can
+/// display another wallet's saved causes.
+pub fn get_saved(env: &Env, user: Address) -> Vec<u32> {
+    get_saved_campaigns(env, &user)
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -91,6 +91,10 @@ pub enum Error {
     GoalMetCancellationNotAllowed = 42,
     /// The requested campaign lifecycle state transition is not valid from the current state.
     InvalidStateTransition = 43,
+    /// The campaign is already in the wallet's saved/bookmarked list.
+    CampaignAlreadyBookmarked = 44,
+    /// The campaign is not in the wallet's saved/bookmarked list.
+    CampaignNotBookmarked = 45,
 }
 
 impl Error {
@@ -142,6 +146,8 @@ impl Error {
             Error::InvalidVestingDelay => "InvalidVestingDelay",
             Error::GoalMetCancellationNotAllowed => "GoalMetCancellationNotAllowed",
             Error::InvalidStateTransition => "InvalidStateTransition",
+            Error::CampaignAlreadyBookmarked => "CampaignAlreadyBookmarked",
+            Error::CampaignNotBookmarked => "CampaignNotBookmarked",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub(crate) const AUTO_PAUSE_BURST_CHECK_MIN_RAISED_BPS: i128 = 5000;
 pub(crate) const LIST_MAX_LIMIT: u32 = 50;
 
 mod admin;
+mod bookmarks;
 mod campaigns;
 mod constants;
 mod contributions;
@@ -574,6 +575,26 @@ impl ProofOfHeart {
 
     pub fn get_creator_stats(env: Env, creator: Address) -> CreatorStats {
         queries::get_creator_stats(&env, creator)
+    }
+
+    // ── Bookmarks / saved campaigns ───────────────────────────────────────────
+
+    /// Saves `campaign_id` to `user`'s on-chain bookmark list. Requires
+    /// `user`'s authorization.
+    pub fn save_campaign(env: Env, user: Address, campaign_id: u32) -> Result<(), Error> {
+        bookmarks::save_campaign(&env, user, campaign_id)
+    }
+
+    /// Removes `campaign_id` from `user`'s on-chain bookmark list. Requires
+    /// `user`'s authorization.
+    pub fn remove_saved_campaign(env: Env, user: Address, campaign_id: u32) -> Result<(), Error> {
+        bookmarks::remove_saved_campaign(&env, user, campaign_id)
+    }
+
+    /// Returns the list of campaign ids `user` has bookmarked, in the order
+    /// they were saved.
+    pub fn get_saved_campaigns(env: Env, user: Address) -> soroban_sdk::Vec<u32> {
+        bookmarks::get_saved(&env, user)
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -36,6 +36,7 @@ impl StorageKey for CampaignKey {}
 impl StorageKey for ContributionKey {}
 impl StorageKey for VotingKey {}
 impl StorageKey for RevenueKey {}
+impl StorageKey for BookmarkKey {}
 
 /// Keys for platform administration and global configuration state.
 ///
@@ -169,6 +170,13 @@ pub enum RevenueKey {
     /// Number of distinct contributors who have claimed revenue at least
     /// once for a campaign, keyed by campaign ID (#526).
     ContributorRevenueClaimants(u32),
+}
+
+/// Keys for a wallet's saved/bookmarked campaigns (#507).
+#[contracttype]
+pub enum BookmarkKey {
+    /// A wallet's saved campaign ids, keyed by the wallet address.
+    SavedCampaigns(Address),
 }
 
 // ── Campaign ──────────────────────────────────────────────────────────────────
@@ -992,4 +1000,26 @@ pub fn set_cancelled_campaign_count(env: &Env, count: u32) {
 
 pub fn increment_cancelled_campaign_count(env: &Env) {
     set_cancelled_campaign_count(env, get_cancelled_campaign_count(env) + 1);
+}
+
+// ── Saved / bookmarked campaigns ──────────────────────────────────────────────
+
+/// Returns the list of campaign ids a wallet has bookmarked, in the order
+/// they were saved. Defaults to an empty list.
+pub fn get_saved_campaigns(env: &Env, user: &Address) -> Vec<u32> {
+    let key = BookmarkKey::SavedCampaigns(user.clone());
+    let val: Option<Vec<u32>> = env.storage().persistent().get(&key);
+    if let Some(ids) = val {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+        ids
+    } else {
+        Vec::new(env)
+    }
+}
+
+/// Stores a wallet's list of bookmarked campaign ids and extends its TTL.
+pub fn set_saved_campaigns(env: &Env, user: &Address, ids: &Vec<u32>) {
+    persistent_set!(env, BookmarkKey::SavedCampaigns(user.clone()), ids);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod helpers;
 
 mod test_admin;
 mod test_benchmark;
+mod test_bookmarks;
 mod test_campaigns;
 mod test_contributions;
 mod test_lifecycle;

--- a/src/tests/test_bookmarks.rs
+++ b/src/tests/test_bookmarks.rs
@@ -1,0 +1,141 @@
+use super::helpers::*;
+use crate::{Category, Error};
+use soroban_sdk::String;
+
+#[test]
+fn test_save_and_get_saved_campaigns() {
+    let (env, _admin, creator, contributor1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 1"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let id2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 2"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    assert_eq!(
+        client.get_saved_campaigns(&contributor1),
+        soroban_sdk::vec![&env]
+    );
+
+    client.save_campaign(&contributor1, &id1);
+    client.save_campaign(&contributor1, &id2);
+
+    let saved = client.get_saved_campaigns(&contributor1);
+    assert_eq!(saved.len(), 2);
+    assert_eq!(saved.get(0).unwrap(), id1);
+    assert_eq!(saved.get(1).unwrap(), id2);
+}
+
+#[test]
+fn test_save_campaign_nonexistent_fails() {
+    let (_env, _admin, _creator, contributor1, _c2, _token, _token_admin, client) = setup_env();
+
+    let result = client.try_save_campaign(&contributor1, &999);
+    assert_eq!(result, Err(Ok(Error::CampaignNotFound)));
+}
+
+#[test]
+fn test_save_campaign_duplicate_fails() {
+    let (env, _admin, creator, contributor1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.save_campaign(&contributor1, &id);
+    let result = client.try_save_campaign(&contributor1, &id);
+    assert_eq!(result, Err(Ok(Error::CampaignAlreadyBookmarked)));
+}
+
+#[test]
+fn test_remove_saved_campaign() {
+    let (env, _admin, creator, contributor1, _c2, _token, _token_admin, client) = setup_env();
+
+    let id1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 1"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    let id2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign 2"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.save_campaign(&contributor1, &id1);
+    client.save_campaign(&contributor1, &id2);
+
+    client.remove_saved_campaign(&contributor1, &id1);
+
+    let saved = client.get_saved_campaigns(&contributor1);
+    assert_eq!(saved.len(), 1);
+    assert_eq!(saved.get(0).unwrap(), id2);
+}
+
+#[test]
+fn test_remove_saved_campaign_not_bookmarked_fails() {
+    let (_env, _admin, _creator, contributor1, _c2, _token, _token_admin, client) = setup_env();
+
+    let result = client.try_remove_saved_campaign(&contributor1, &1);
+    assert_eq!(result, Err(Ok(Error::CampaignNotBookmarked)));
+}
+
+#[test]
+fn test_saved_campaigns_are_per_wallet() {
+    let (env, _admin, creator, contributor1, contributor2, _token, _token_admin, client) =
+        setup_env();
+
+    let id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign"),
+        String::from_str(&env, "Desc"),
+        1000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.save_campaign(&contributor1, &id);
+
+    assert_eq!(client.get_saved_campaigns(&contributor1).len(), 1);
+    assert_eq!(client.get_saved_campaigns(&contributor2).len(), 0);
+}


### PR DESCRIPTION
- **On-chain campaign bookmarks (#507):** Adds `save_campaign`, `remove_saved_campaign`, and `get_saved_campaigns` contract functions backed by a new `BookmarkKey::SavedCampaigns(Address)` persistent storage key, so any wallet/app can track and read a user's saved causes directly from chain state without a centralized backend. `save_campaign` validates the campaign exists and rejects duplicates (`CampaignAlreadyBookmarked`); `remove_saved_campaign` rejects removing a campaign that isn't bookmarked (`CampaignNotBookmarked`). Both require the wallet's authorization.
- **Dependabot config for soroban-sdk (#499):** Adds `.github/dependabot.yml` tracking the `cargo` ecosystem (weekly) so upgrades from the pinned `soroban-sdk = "=20.1.0"` to current 22.x land as reviewable PRs, plus a `github-actions` entry to keep CI actions current.
- **Scripted deployment (#495):** Adds `scripts/deploy.sh` with `deploy-testnet`, `deploy-mainnet`, `init`, and `verify` commands that automate the manual `stellar` CLI steps in `docs/DEPLOYMENT.md`. Cross-linked the script from the doc's intro and added a "Scripted Deployment" section with usage examples.

## Test plan

- [x] `cargo test` — 310 tests pass, including 6 new bookmark tests (save, get, duplicate rejection, not-found rejection, remove, remove-not-bookmarked rejection, per-wallet isolation)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --features testutils -- -D warnings` — clean
- [x] `cargo build --target wasm32-unknown-unknown --release` — builds successfully
- [x] `bash -n scripts/deploy.sh` — syntax OK; manually exercised `--help` and argument-validation paths (missing `CONTRACT_ID`/`ADMIN_ADDRESS`/`TOKEN_ADDRESS` fail fast with clear errors)

Closes #507
Closes #499
Closes #495