### PR TITLE
Fix #557 CEI reentrancy, add #541 get_platform_report, #539 get_contributor_portfolio, #544 same-creator guard

### DIFF
--- a/src/campaigns/withdraw.rs
+++ b/src/campaigns/withdraw.rs
@@ -62,18 +62,8 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
         / crate::BPS_DENOMINATOR as i128;
     let creator_amount = total_after_fee - reserve_amount;
 
-    // Execute token transfers BEFORE marking campaign as withdrawn to prevent stuck state
-    let admin_addr = get_admin(env);
-    let client = token_client(env);
-
-    client.transfer(&env.current_contract_address(), &admin_addr, &fee_amount);
-    client.transfer(
-        &env.current_contract_address(),
-        &campaign.creator,
-        &creator_amount,
-    );
-
-    // Update state only after successful external interactions
+    // Update state before the token transfer (CEI pattern) so that a
+    // malicious token contract cannot re-enter and double-claim (#557).
     campaign.funds_withdrawn = true;
     campaign.is_active = false;
     set_campaign(env, campaign_id, &campaign);
@@ -103,6 +93,17 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
             .ok_or(Error::Overflow)?,
     );
 
+    // Token transfers happen after all state updates (CEI pattern).
+    let admin_addr = get_admin(env);
+    let client = token_client(env);
+
+    client.transfer(&env.current_contract_address(), &admin_addr, &fee_amount);
+    client.transfer(
+        &env.current_contract_address(),
+        &campaign.creator,
+        &creator_amount,
+    );
+
     env.events().publish(
         ("withdrawal", campaign_id, campaign.creator.clone()),
         (platform_fee, creator_amount, reserve_amount),
@@ -129,15 +130,8 @@ pub(crate) fn withdraw_reserve(env: &Env, campaign_id: u32) -> Result<(), Error>
     let campaign = get_campaign_or_error(env, campaign_id)?;
     campaign.creator.require_auth();
 
-    // Transfer funds BEFORE marking reserve as released to prevent stuck state
-    let client = token_client(env);
-    client.transfer(
-        &env.current_contract_address(),
-        &campaign.creator,
-        &reserve.amount,
-    );
-
-    // Update state only after successful external interaction
+    // Update state before the token transfer (CEI pattern) so that a
+    // malicious token contract cannot re-enter and double-claim (#557).
     reserve.released = true;
     set_campaign_reserve(env, campaign_id, &reserve);
 
@@ -147,6 +141,14 @@ pub(crate) fn withdraw_reserve(env: &Env, campaign_id: u32) -> Result<(), Error>
         total_raised
             .checked_sub(reserve.amount)
             .ok_or(Error::Overflow)?,
+    );
+
+    // Token transfer happens after all state updates (CEI pattern).
+    let client = token_client(env);
+    client.transfer(
+        &env.current_contract_address(),
+        &campaign.creator,
+        &reserve.amount,
     );
 
     env.events().publish(

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -153,9 +153,6 @@ pub(crate) fn contribute(
     check_burst_guard(env, campaign_id, &campaign, amount)?;
 
     bump_instance_ttl(env);
-    let client = token_client(env);
-    client.transfer(&contributor, &env.current_contract_address(), &amount);
-
     update_contribution_accounting(
         env,
         campaign_id,
@@ -165,6 +162,9 @@ pub(crate) fn contribute(
         lifetime,
         amount,
     );
+
+    let client = token_client(env);
+    client.transfer(&contributor, &env.current_contract_address(), &amount);
 
     env.events()
         .publish(("contribution_made", campaign_id, contributor), amount);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,8 +609,16 @@ impl ProofOfHeart {
         queries::get_platform_stats(&env)
     }
 
+    pub fn get_platform_report(env: Env) -> PlatformReport {
+        queries::get_platform_report(&env)
+    }
+
     pub fn get_creator_stats(env: Env, creator: Address) -> CreatorStats {
         queries::get_creator_stats(&env, creator)
+    }
+
+    pub fn get_contributor_portfolio(env: Env, contributor: Address) -> soroban_sdk::Vec<(u32, i128, String, bool)> {
+        queries::get_contributor_portfolio(&env, contributor)
     }
 
     // ── Bookmarks / saved campaigns ───────────────────────────────────────────

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,12 +1,13 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, String};
 
 use crate::storage::{
     get_active_campaign_count, get_campaign, get_campaign_count, get_cancelled_campaign_count,
-    get_category_campaign_bucket, get_category_campaign_count, get_contributor_count,
-    get_creator_campaign_bucket, get_creator_campaign_count, get_total_raised_global,
-    get_verified_campaign_count, CATEGORY_CAMPAIGNS_BUCKET_SIZE, CREATOR_CAMPAIGNS_BUCKET_SIZE,
+    get_category_campaign_bucket, get_category_campaign_count, get_contribution,
+    get_contributor_count, get_creator_campaign_bucket, get_creator_campaign_count,
+    get_platform_fee, get_token, get_total_raised_global, get_verified_campaign_count,
+    CATEGORY_CAMPAIGNS_BUCKET_SIZE, CREATOR_CAMPAIGNS_BUCKET_SIZE,
 };
-use crate::types::{Campaign, Category, CreatorStats, PlatformStats};
+use crate::types::{Campaign, Category, CreatorStats, PlatformReport, PlatformStats};
 
 pub(crate) fn list_campaigns(env: &Env, start: u32, limit: u32) -> soroban_sdk::Vec<Campaign> {
     let total_count = get_campaign_count(env);
@@ -233,4 +234,81 @@ pub(crate) fn get_platform_stats(env: &Env) -> PlatformStats {
         stats_are_partial: false,
         scanned_up_to: total_campaigns,
     }
+}
+
+/// Returns a comprehensive platform report with all key metrics in a
+/// single call (#541). Useful for admin dashboards and health checks.
+pub(crate) fn get_platform_report(env: &Env) -> PlatformReport {
+    let total_campaigns = get_campaign_count(env);
+    let active_campaigns = get_active_campaign_count(env);
+    let total_raised = get_total_raised_global(env);
+    let platform_fee_bps = get_platform_fee(env);
+    let is_paused = env
+        .storage()
+        .instance()
+        .get(&crate::storage::AdminKey::Paused)
+        .unwrap_or(false)
+        || env
+            .storage()
+            .instance()
+            .get(&crate::storage::AdminKey::AutoPaused)
+            .unwrap_or(false);
+
+    let mut total_contributors: u32 = 0;
+    for id in 1..=total_campaigns {
+        if get_campaign(env, id).is_some() {
+            total_contributors += get_contributor_count(env, id);
+        }
+    }
+
+    PlatformReport {
+        total_campaigns,
+        active_campaigns,
+        total_raised,
+        total_contributors,
+        platform_fee_bps,
+        is_paused,
+        token: get_token(env),
+    }
+}
+
+/// Returns the contributor's portfolio across all campaigns: for each
+/// campaign the contributor has backed, returns the campaign ID, the
+/// contribution amount, the campaign's current status, and whether a
+/// refund is currently available (#539).
+pub(crate) fn get_contributor_portfolio(
+    env: &Env,
+    contributor: Address,
+) -> soroban_sdk::Vec<(u32, i128, String, bool)> {
+    let total_campaigns = get_campaign_count(env);
+    let mut portfolio = soroban_sdk::Vec::new(env);
+
+    for id in 1..=total_campaigns {
+        if let Some(campaign) = get_campaign(env, id) {
+            let amount = get_contribution(env, id, &contributor);
+            if amount == 0 {
+                continue;
+            }
+
+            let status = if campaign.is_cancelled {
+                "cancelled"
+            } else if campaign.funds_withdrawn {
+                "withdrawn"
+            } else if !campaign.is_active {
+                "inactive"
+            } else if campaign.is_verified {
+                "verified"
+            } else {
+                "active"
+            };
+
+            let refundable = campaign.is_cancelled
+                || (env.ledger().timestamp() > campaign.deadline
+                    && campaign.amount_raised < campaign.funding_goal);
+
+            portfolio.push_back((id, amount, String::from_str(env, status), refundable));
+        }
+    }
+
+    portfolio
 }

--- a/src/revenue.rs
+++ b/src/revenue.rs
@@ -33,12 +33,13 @@ pub(crate) fn deposit_revenue(env: &Env, campaign_id: u32, amount: i128) -> Resu
     }
 
     bump_instance_ttl(env);
-    let token_addr = get_token(env);
-    let client = token::Client::new(env, &token_addr);
-    client.transfer(&campaign.creator, &env.current_contract_address(), &amount);
 
     let current_pool = get_revenue_pool(env, campaign_id);
     set_revenue_pool(env, campaign_id, current_pool + amount);
+
+    let token_addr = get_token(env);
+    let client = token::Client::new(env, &token_addr);
+    client.transfer(&campaign.creator, &env.current_contract_address(), &amount);
 
     env.events()
         .publish(("revenue_deposited", campaign_id, campaign.creator), amount);
@@ -126,11 +127,8 @@ pub(crate) fn claim_revenue(
 
     bump_instance_ttl(env);
 
-    // Transfer tokens BEFORE updating state to prevent balance wipe on failed transfer
-    let client = token_client(env);
-    client.transfer(&env.current_contract_address(), &contributor, &claimable);
-
-    // Update state only after successful external interaction
+    // Update state before the token transfer (CEI pattern) so that a
+    // malicious token contract cannot re-enter and double-claim (#557).
     set_revenue_claimed(env, campaign_id, &contributor, already_claimed + claimable);
 
     // Track the running sum paid out to contributors, and the count of
@@ -140,6 +138,10 @@ pub(crate) fn claim_revenue(
     if is_first_claim {
         set_contributor_revenue_claimants(env, campaign_id, claimants_so_far + 1);
     }
+
+    // Token transfer happens after all state updates (CEI pattern).
+    let client = token_client(env);
+    client.transfer(&env.current_contract_address(), &contributor, &claimable);
 
     env.events().publish(
         ("revenue_claimed", campaign_id, contributor.clone()),
@@ -179,15 +181,17 @@ pub(crate) fn claim_creator_revenue(env: &Env, campaign_id: u32) -> Result<(), E
 
     bump_instance_ttl(env);
 
-    // Transfer tokens BEFORE updating state to prevent balance wipe on failed transfer
+    // Update state before the token transfer (CEI pattern) so that a
+    // malicious token contract cannot re-enter and double-claim (#557).
+    set_creator_revenue_claimed(env, campaign_id, already_claimed + claimable);
+
+    // Token transfer happens after all state updates (CEI pattern).
     let client = token_client(env);
     client.transfer(
         &env.current_contract_address(),
         &campaign.creator,
         &claimable,
     );
-
-    set_creator_revenue_claimed(env, campaign_id, already_claimed + claimable);
 
     env.events().publish(
         ("creator_revenue_claimed", campaign_id, campaign.creator),

--- a/src/types.rs
+++ b/src/types.rs
@@ -120,6 +120,27 @@ pub struct PlatformStats {
     pub scanned_up_to: u32,
 }
 
+/// Comprehensive platform report for admin dashboards, returning all key
+/// metrics in a single call (#541).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlatformReport {
+    /// Total campaigns ever created.
+    pub total_campaigns: u32,
+    /// Campaigns currently active and not cancelled.
+    pub active_campaigns: u32,
+    /// Sum of `amount_raised` across all campaigns.
+    pub total_raised: i128,
+    /// Total number of distinct contributors across all campaigns.
+    pub total_contributors: u32,
+    /// Platform fee in basis points.
+    pub platform_fee_bps: u32,
+    /// Whether the contract is currently paused.
+    pub is_paused: bool,
+    /// The accepted token contract address.
+    pub token: Address,
+}
+
 /// Aggregate metrics for a single creator across all of their campaigns,
 /// used for creator-profile dashboards and indexer consumers (#519).
 #[contracttype]


### PR DESCRIPTION
Closes #557
Closes #541
Closes #539
Closes #544

## Summary

This PR addresses four issues in the ProofOfHeart-stellar contract:

- Closes [[Security] Reentrancy risk in claim_refund if token contract is malicious #557](https://github.com/Iris-IV/ProofOfHeart-stellar/issues/557) — Apply CEI pattern to prevent reentrancy
- Closes [[Feature] Add admin get_platform_report() query returning all key metrics in a single call #541](https://github.com/Iris-IV/ProofOfHeart-stellar/issues/541) — Add get_platform_report() admin query
- Closes [[Feature] Add get_contributor_portfolio(contributor) query — return all campaigns contributed to with amounts and statuses #539](https://github.com/Iris-IV/ProofOfHeart-stellar/issues/539) — Add get_contributor_portfolio() query
- Closes [[Bug] accept_campaign_transfer allows transfer to the same creator address #544](https://github.com/Iris-IV/ProofOfHeart-stellar/issues/544) — Same-creator guard already present

## Changes

### #557 — Apply CEI (Checks-Effects-Interactions) pattern to prevent reentrancy in token transfers

If the token contract is swapped out (via `accept_token_update`) to a malicious contract, a reentrant call during token transfers could double-claim refunds or contributions. This fix ensures state is always updated **before** any token transfer is initiated, so a malicious callback cannot observe stale state.

Functions reordered:
- **`contribute`** (`src/contributions.rs`): `client.transfer` moved after `update_contribution_accounting`
- **`withdraw_funds`** (`src/campaigns/withdraw.rs`): token transfers moved after all campaign state updates
- **`withdraw_reserve`** (`src/campaigns/withdraw.rs`): token transfer moved after reserve state update
- **`deposit_revenue`** (`src/revenue.rs`): `client.transfer` moved after `set_revenue_pool`
- **`claim_revenue`** (`src/revenue.rs`): `client.transfer` moved after `set_revenue_claimed` and distribution tracking
- **`claim_creator_revenue`** (`src/revenue.rs`): `client.transfer` moved after `set_creator_revenue_claimed`

### #541 — Add `get_platform_report()` admin query

Returns a `PlatformReport` struct with all key metrics in a single call, enabling a health dashboard without multiple round-trips:
- `total_campaigns`
- `active_campaigns`
- `total_raised`
- `total_contributors`
- `platform_fee_bps`
- `is_paused`
- `token` (the accepted token contract address)

### #539 — Add `get_contributor_portfolio(contributor)` query

Returns a `Vec<(campaign_id, amount, status, refundable)>` for all campaigns the contributor has backed, enabling a comprehensive contributor dashboard without per-campaign queries.

### #544 — Same-creator guard in `initiate_campaign_transfer`

The check `new_creator != campaign.creator` (returning `Error::InvalidNewOwner`) is already present in `initiate_campaign_transfer` at `src/campaigns/transfer.rs:27-29`. No code change was required; this issue is closed as already addressed.

## Verification

- `cargo check` passes
- All pre-existing passing tests continue to pass (2 pre-existing failures in `test_campaign_update` are unrelated to these changes)