### PR TITLE
fix: correct revenue_deposited event topics in docs and add topic ver…

### DIFF
--- a/EVENT_PAYLOADS.md
+++ b/EVENT_PAYLOADS.md
@@ -158,9 +158,9 @@ Every `publish(...)` call in the contract, with its topics, data shape, and the 
 
 | Field   | Value                                                      |
 |---------|------------------------------------------------------------|
-| Topics  | `("revenue_deposited", campaign_id: u32)`                  |
+| Topics  | `("revenue_deposited", campaign_id: u32, creator: Address)`|
 | Data    | `amount: i128`                                             |
-| Source  | `lib.rs:842` — `deposit_revenue()`                         |
+| Source  | `src/revenue.rs:44` — `deposit_revenue()`                  |
 
 ---
 

--- a/src/tests/test_revenue_deposit.rs
+++ b/src/tests/test_revenue_deposit.rs
@@ -1,6 +1,6 @@
 use super::helpers::*;
 use crate::{Category, CreateCampaignParams, Error};
-use soroban_sdk::String;
+use soroban_sdk::{Address, FromVal, String, TryFromVal};
 
 #[test]
 fn test_deposit_revenue_negative_amount() {
@@ -199,4 +199,54 @@ fn test_deposit_revenue_cancelled_campaign() {
     // Depositing revenue into a cancelled campaign should fail
     let res = client.try_deposit_revenue(&campaign_id, &500);
     assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotActive);
+}
+
+#[test]
+fn test_deposit_revenue_event_includes_creator() {
+    let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&creator, &5000);
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Event Topic Test"),
+        description: String::from_str(&env, "Verify revenue_deposited event topics"),
+        funding_goal: 1000,
+        duration_days: 30,
+        category: Category::EducationalStartup,
+        has_revenue_sharing: true,
+        revenue_share_percentage: 2000,
+        max_contribution_per_user: 0i128,
+    });
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    client.withdraw_funds(&campaign_id);
+
+    token_admin.mint(&creator, &2000);
+    client.deposit_revenue(&campaign_id, &2000);
+
+    let events = env.events().all();
+    let deposit_event = events
+        .iter()
+        .find(|(_, topics, _)| {
+            topics
+                .get(0)
+                .and_then(|v| String::try_from_val(&env, &v).ok())
+                .map(|topic| topic == String::from_str(&env, "revenue_deposited"))
+                .unwrap_or(false)
+        })
+        .expect("revenue_deposited event must exist");
+
+    let topics = &deposit_event.1;
+    assert_eq!(topics.len(), 3, "revenue_deposited must have 3 topics");
+
+    let topic_campaign_id: u32 = FromVal::from_val(&env, &topics.get(1).unwrap());
+    assert_eq!(topic_campaign_id, campaign_id);
+
+    let topic_creator: Address = FromVal::from_val(&env, &topics.get(2).unwrap());
+    assert_eq!(topic_creator, creator);
+
+    let amount: i128 = FromVal::from_val(&env, &deposit_event.2);
+    assert_eq!(amount, 2000);
 }


### PR DESCRIPTION
## Summary

This PR fixes the `revenue_deposited` event documentation to match the contract's actual behavior and adds regression coverage to ensure the documented event structure remains accurate.

The contract already publishes the `revenue_deposited` event with a three-field topic tuple containing the event name, campaign ID, and creator address. However, `EVENT_PAYLOADS.md` documented only a two-field tuple, which could cause indexers or downstream consumers to parse the event incorrectly.

## Changes

### Updated Event Documentation

- Corrected the `revenue_deposited` event topics in `EVENT_PAYLOADS.md` to include the creator address.
- Updated the source reference to the current implementation in `src/revenue.rs`.

### Added Regression Test

- Added `test_deposit_revenue_event_includes_creator`.
- Verified that the published event contains:
  - `"revenue_deposited"`
  - The correct `campaign_id`
  - The correct creator `Address`
- Added regression coverage to ensure the documented event topic structure remains in sync with the contract implementation.

## Notes

- No contract behavior was changed.
- The implementation already emitted the correct event topics. This PR updates the documentation to reflect the existing implementation and adds a regression test to prevent future documentation drift.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --features testutils -- -D warnings`
- `cargo test --features testutils`

### Results

- `cargo fmt --check` passed.
- `cargo clippy --all-targets --features testutils -- -D warnings` passed.
- `395/397` tests passed (`2` pre-existing unrelated test failures).

Closes #673