### PR TITLE
fix: use 1-address-1-vote model to prevent flash-loan voting (#469)

### DIFF
--- a/src/tests/test_regressions.rs
+++ b/src/tests/test_regressions.rs
@@ -273,9 +273,13 @@ fn test_set_personal_cap_cannot_exceed_max_contribution_per_user() {
     assert_eq!(res2.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
-// ── #354 vote weight checked addition ──
+// ── #354 / #469 vote weight safe addition ──
+/// With the 1-address-1-vote model (#469), vote weight is incremented by 1
+/// regardless of token balance. Even when the stored weight is near i128::MAX,
+/// a vote still succeeds because we only add 1 (not the voter's balance),
+/// preventing flash-loan attacks that inflate voting weight.
 #[test]
-fn test_vote_weight_overflow_fails() {
+fn test_vote_weight_does_not_overflow_with_1_address_1_vote() {
     let (env, _admin, creator, contributor, _, _token, token_admin, client) = setup_env();
     let campaign_id = client.create_campaign(&make_campaign_params_simple(&env, &creator));
 
@@ -289,8 +293,10 @@ fn test_vote_weight_overflow_fails() {
 
     token_admin.mint(&contributor, &501);
 
-    let res = client.try_vote_on_campaign(&campaign_id, &contributor, &true);
-    assert_eq!(res.unwrap_err().unwrap(), Error::Overflow);
+    // With 1-address-1-vote, the weight only increments by 1, so no overflow occurs
+    // even when ApproveWeight is near i128::MAX (#469).
+    client.vote_on_campaign(&campaign_id, &contributor, &true);
+    assert_eq!(client.get_approve_votes(&campaign_id), 1);
 }
 
 // ── #360 resume_campaign admin-path coverage ──────────────────────────────────

--- a/src/tests/test_voting.rs
+++ b/src/tests/test_voting.rs
@@ -972,12 +972,15 @@ proptest! {
 
     #[test]
     fn prop_half_approval_gives_half_bps(votes in 10u32..=1_000_000u32) {
+        // Use an even vote count so the 50/50 split is exact: doubling the
+        // generated value guarantees half == votes / 2 exactly, so the
+        // computed bps is exactly 5000 with no rounding error.
+        let votes = votes * 2;
         let half = votes / 2;
         let approval_bps = calculate_approval_bps(half, votes);
-        // Allow for rounding error of 1 bps
-        prop_assert!(
-            (4_900..=5_000).contains(&approval_bps),
-            "50% approval should give ~5000 bps, got {}",
+        prop_assert_eq!(
+            approval_bps, 5_000,
+            "50% approval should give 5000 bps, got {}",
             approval_bps
         );
     }

--- a/src/tests/test_voting.rs
+++ b/src/tests/test_voting.rs
@@ -621,17 +621,18 @@ fn test_vote_on_campaign_after_withdraw_fails() {
 }
 
 #[test]
-fn test_vote_on_campaign_token_weighted() {
+fn test_vote_on_campaign_one_address_one_vote() {
     let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
         setup_env();
 
+    // contributor1 has 5000 tokens, contributor2 has only 1000 — both get 1 vote (#469).
     token_admin.mint(&contributor1, &5000);
     token_admin.mint(&contributor2, &1000);
 
     let campaign_id = client.create_campaign(&make_params(
         creator.clone(),
-        String::from_str(&env, "Weighted Vote Test"),
-        String::from_str(&env, "Test token-weighted voting"),
+        String::from_str(&env, "1-Address-1-Vote Test"),
+        String::from_str(&env, "Test 1-address-1-vote model"),
         1000,
         30,
         Category::Learner,
@@ -643,6 +644,7 @@ fn test_vote_on_campaign_token_weighted() {
     client.vote_on_campaign(&campaign_id, &contributor1, &true);
     client.vote_on_campaign(&campaign_id, &contributor2, &false);
 
+    // Each voter contributes exactly 1 to the count regardless of balance.
     assert_eq!(client.get_approve_votes(&campaign_id), 1);
     assert_eq!(client.get_reject_votes(&campaign_id), 1);
 }
@@ -899,10 +901,11 @@ fn test_min_voting_balance_threshold_enforcement() {
 
 // ── Pure arithmetic helpers ──────────────────────────────────────────────────
 
-/// Calculate approval percentage in basis points (0-10000)
-fn calculate_approval_bps(approve_weight: i128, total_weight: i128) -> u32 {
-    if total_weight > 0 {
-        ((approve_weight * 10_000) / total_weight) as u32
+/// Calculate approval percentage in basis points (0-10000) from vote counts.
+/// Uses u64 to avoid overflow when multiplying by 10_000.
+fn calculate_approval_bps(approve_votes: u32, total_votes: u32) -> u32 {
+    if total_votes > 0 {
+        ((approve_votes as u64 * 10_000) / total_votes as u64) as u32
     } else {
         0
     }
@@ -925,11 +928,6 @@ fn arb_vote_count() -> impl Strategy<Value = u32> {
     0u32..=1_000_000u32
 }
 
-/// Token weights: 0 to 10 billion stroops
-fn arb_token_weight() -> impl Strategy<Value = i128> {
-    0i128..=10_000_000_000i128
-}
-
 /// Approval threshold in basis points (0-10000, i.e., 0-100%)
 fn arb_threshold_bps() -> impl Strategy<Value = u32> {
     0u32..=10_000u32
@@ -945,11 +943,11 @@ fn arb_min_quorum() -> impl Strategy<Value = u32> {
 proptest! {
     #[test]
     fn prop_approval_bps_in_valid_range(
-        approve_weight in arb_token_weight(),
-        reject_weight in arb_token_weight(),
+        approve_votes in arb_vote_count(),
+        reject_votes in arb_vote_count(),
     ) {
-        let total_weight = approve_weight + reject_weight;
-        let approval_bps = calculate_approval_bps(approve_weight, total_weight);
+        let total_votes = approve_votes.saturating_add(reject_votes);
+        let approval_bps = calculate_approval_bps(approve_votes, total_votes);
         prop_assert!(
             approval_bps <= 10_000,
             "approval_bps ({}) must be <= 10000",
@@ -958,8 +956,8 @@ proptest! {
     }
 
     #[test]
-    fn prop_full_approval_gives_max_bps(weight in arb_token_weight()) {
-        let approval_bps = calculate_approval_bps(weight, weight);
+    fn prop_full_approval_gives_max_bps(votes in 1u32..=1_000_000u32) {
+        let approval_bps = calculate_approval_bps(votes, votes);
         prop_assert_eq!(
             approval_bps, 10_000,
             "100% approval should give 10000 bps"
@@ -967,18 +965,18 @@ proptest! {
     }
 
     #[test]
-    fn prop_zero_approval_gives_zero_bps(reject_weight in arb_token_weight()) {
-        let approval_bps = calculate_approval_bps(0, reject_weight);
+    fn prop_zero_approval_gives_zero_bps(reject_votes in 1u32..=1_000_000u32) {
+        let approval_bps = calculate_approval_bps(0, reject_votes);
         prop_assert_eq!(approval_bps, 0, "0% approval should give 0 bps");
     }
 
     #[test]
-    fn prop_half_approval_gives_half_bps(weight in 2i128..=10_000_000_000i128) {
-        let half = weight / 2;
-        let approval_bps = calculate_approval_bps(half, weight);
+    fn prop_half_approval_gives_half_bps(votes in 10u32..=1_000_000u32) {
+        let half = votes / 2;
+        let approval_bps = calculate_approval_bps(half, votes);
         // Allow for rounding error of 1 bps
         prop_assert!(
-            (4_999..=5_000).contains(&approval_bps),
+            (4_900..=5_000).contains(&approval_bps),
             "50% approval should give ~5000 bps, got {}",
             approval_bps
         );
@@ -1014,28 +1012,19 @@ proptest! {
     }
 
     #[test]
-    fn prop_weight_no_overflow(
-        approve_weight in 0i128..=5_000_000_000i128,
-        reject_weight in 0i128..=5_000_000_000i128,
-    ) {
-        let total = approve_weight.checked_add(reject_weight);
-        prop_assert!(total.is_some(), "weight addition should not overflow");
-    }
-
-    #[test]
     fn prop_approval_monotonic(
-        base_approve in 0i128..=1_000_000i128,
-        extra_approve in 0i128..=1_000_000i128,
-        reject_weight in 1i128..=1_000_000i128,
+        base_approve in 0u32..=500_000u32,
+        extra_approve in 0u32..=500_000u32,
+        reject_votes in 1u32..=500_000u32,
     ) {
-        let bps1 = calculate_approval_bps(base_approve, base_approve + reject_weight);
+        let bps1 = calculate_approval_bps(base_approve, base_approve.saturating_add(reject_votes));
         let bps2 = calculate_approval_bps(
-            base_approve + extra_approve,
-            base_approve + extra_approve + reject_weight
+            base_approve.saturating_add(extra_approve),
+            base_approve.saturating_add(extra_approve).saturating_add(reject_votes),
         );
         prop_assert!(
             bps2 >= bps1,
-            "adding approval weight should not decrease approval bps: {} -> {}",
+            "adding approval votes should not decrease approval bps: {} -> {}",
             bps1, bps2
         );
     }
@@ -1044,14 +1033,11 @@ proptest! {
     fn prop_verification_requires_both_conditions(
         approve_votes in arb_vote_count(),
         reject_votes in arb_vote_count(),
-        approve_weight in arb_token_weight(),
-        reject_weight in arb_token_weight(),
         min_quorum in arb_min_quorum(),
         threshold_bps in 5_000u32..=10_000u32, // 50-100%
     ) {
         let total_votes = approve_votes.saturating_add(reject_votes);
-        let total_weight = approve_weight.saturating_add(reject_weight);
-        let approval_bps = calculate_approval_bps(approve_weight, total_weight);
+        let approval_bps = calculate_approval_bps(approve_votes, total_votes);
 
         let quorum_met = is_quorum_met(total_votes, min_quorum);
         let threshold_met = is_threshold_met(approval_bps, threshold_bps);
@@ -1063,40 +1049,32 @@ proptest! {
         }
     }
 
-    /// Property test for issue #211:
-    /// Verify that voting weights always equal the sum of token-balances of voters
-    /// who chose the same side.
-    ///
-    /// This test generates a set of voters with their balances and voting choices,
-    /// then verifies the invariant:
-    /// approve_weight = sum(balances of voters who approved)
-    /// reject_weight = sum(balances of voters who rejected)
+    /// Property test for the 1-address-1-vote model (#469):
+    /// Every voter contributes exactly 1 to the count regardless of token balance.
+    /// This confirms that the vote counts equal the number of voters on each side.
     #[test]
-    fn prop_voting_weights_equal_sum_of_balances(
-        // Generate random voters with their balances and choices
-        approval_balances in prop::collection::vec(1i128..=1_000_000i128, 0..20),
-        rejection_balances in prop::collection::vec(1i128..=1_000_000i128, 0..20),
+    fn prop_one_address_one_vote_invariant(
+        // Generate random numbers of approving and rejecting voters
+        approve_count in 0u32..=10_000u32,
+        reject_count in 0u32..=10_000u32,
     ) {
-        // Calculate expected weights
-        let expected_approve_weight: i128 = approval_balances.iter().sum();
-        let expected_reject_weight: i128 = rejection_balances.iter().sum();
+        // In the 1-address-1-vote model:
+        // - Each approving voter adds exactly 1 to approve_count
+        // - Each rejecting voter adds exactly 1 to reject_count
+        // - approval_bps is computed from counts, not balances
+        let total_votes = approve_count.saturating_add(reject_count);
+        let approval_bps = calculate_approval_bps(approve_count, total_votes);
+        prop_assert!(approval_bps <= 10_000);
 
-        // In the actual voting implementation (from voting.rs cast_vote):
-        // - When approve=true: approve_weight += voter_balance
-        // - When approve=false: reject_weight += voter_balance
-        // This test verifies that summing balances of each group produces the correct weight
-        //
-        // The invariant is:
-        // approve_weight = sum of all voter balances who approved
-        // reject_weight = sum of all voter balances who rejected
-        prop_assert!(
-            expected_approve_weight >= 0,
-            "approve_weight must be non-negative"
-        );
-        prop_assert!(
-            expected_reject_weight >= 0,
-            "reject_weight must be non-negative"
-        );
+        // If all votes approve, approval should be 10000 bps
+        if reject_count == 0 && approve_count > 0 {
+            prop_assert_eq!(approval_bps, 10_000);
+        }
+
+        // If all votes reject, approval should be 0 bps
+        if approve_count == 0 && reject_count > 0 {
+            prop_assert_eq!(approval_bps, 0);
+        }
     }
 }
 
@@ -1106,16 +1084,16 @@ mod unit_tests {
 
     #[test]
     fn test_approval_bps_calculation() {
-        // 60% approval
-        assert_eq!(calculate_approval_bps(600, 1000), 6000);
+        // 60% approval (3 approve / 5 total)
+        assert_eq!(calculate_approval_bps(3, 5), 6000);
 
         // 100% approval
-        assert_eq!(calculate_approval_bps(1000, 1000), 10000);
+        assert_eq!(calculate_approval_bps(1, 1), 10000);
 
         // 0% approval
-        assert_eq!(calculate_approval_bps(0, 1000), 0);
+        assert_eq!(calculate_approval_bps(0, 1), 0);
 
-        // Zero total weight
+        // Zero total votes
         assert_eq!(calculate_approval_bps(0, 0), 0);
     }
 

--- a/src/tests/test_voting_verify.rs
+++ b/src/tests/test_voting_verify.rs
@@ -139,17 +139,18 @@ fn test_vote_on_campaign_after_withdraw_fails() {
 }
 
 #[test]
-fn test_vote_on_campaign_token_weighted() {
+fn test_vote_on_campaign_one_address_one_vote() {
     let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
         setup_env();
 
+    // contributor1 has 5000 tokens, contributor2 has only 1000 — both get 1 vote (#469).
     token_admin.mint(&contributor1, &5000);
     token_admin.mint(&contributor2, &1000);
 
     let campaign_id = client.create_campaign(&make_params(
         creator.clone(),
-        String::from_str(&env, "Weighted Vote Test"),
-        String::from_str(&env, "Test token-weighted voting"),
+        String::from_str(&env, "1-Address-1-Vote Test"),
+        String::from_str(&env, "Test 1-address-1-vote model"),
         1000,
         30,
         Category::Learner,
@@ -161,6 +162,7 @@ fn test_vote_on_campaign_token_weighted() {
     client.vote_on_campaign(&campaign_id, &contributor1, &true);
     client.vote_on_campaign(&campaign_id, &contributor2, &false);
 
+    // Each voter contributes exactly 1 to the count regardless of balance.
     assert_eq!(client.get_approve_votes(&campaign_id), 1);
     assert_eq!(client.get_reject_votes(&campaign_id), 1);
 }

--- a/src/tests/test_voting_verify.rs
+++ b/src/tests/test_voting_verify.rs
@@ -225,7 +225,7 @@ fn test_verify_campaign_with_votes_threshold_not_met() {
 }
 
 #[test]
-fn test_verify_with_votes_weight_overflow_returns_overflow() {
+fn test_verify_with_votes_weight_does_not_overflow_with_1_address_1_vote() {
     let (env, admin, creator, _, _, _token, _token_admin, client) = setup_env();
     client.set_voting_params(&admin, &1, &6000);
 
@@ -241,16 +241,18 @@ fn test_verify_with_votes_weight_overflow_returns_overflow() {
         0i128,
     ));
 
-    // Satisfy quorum, then make approve_weight + reject_weight exceed i128::MAX.
+    // 1-address-1-vote (#469): verify_with_votes tallies vote counts and never
+    // sums weights, so even adversarial i128::MAX weight storage cannot
+    // overflow. The count-based bps (2/3 = 6666 >= 6000) decides the outcome.
     env.as_contract(&client.address, || {
         set_approve_votes(&env, campaign_id, 2);
         set_reject_votes(&env, campaign_id, 1);
         set_approve_weight(&env, campaign_id, i128::MAX);
-        set_reject_weight(&env, campaign_id, 1);
+        set_reject_weight(&env, campaign_id, i128::MAX);
     });
 
     let res = client.try_verify_campaign_with_votes(&campaign_id);
-    assert_eq!(res.unwrap_err().unwrap(), Error::Overflow);
+    assert_eq!(res, Ok(Ok(())));
 }
 
 #[test]

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -55,12 +55,17 @@ pub fn set_params(
 
 /// Records a vote (approve or reject) from a token-holding voter.
 ///
+/// Voting uses a 1-address-1-vote model (#469): every eligible token holder
+/// gets exactly one vote, regardless of their token balance. This prevents
+/// flash-loan attacks where an attacker borrows a large balance, votes with
+/// inflated weight, and returns the tokens before verification.
+///
 /// # Errors
 /// * `CampaignNotFound` - No campaign with the given ID.
 /// * `CampaignAlreadyVerified` - The campaign is already verified.
 /// * `CampaignNotActive` - The campaign is cancelled or inactive.
 /// * `DeadlinePassed` - The voting period has closed (deadline exceeded).
-/// * `NotTokenHolder` - The voter holds no tokens.
+/// * `NotTokenHolder` - The voter holds no tokens or is below the minimum.
 /// * `AlreadyVoted` - The voter has already cast a vote on this campaign.
 pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> Result<(), Error> {
     voter.require_auth();
@@ -89,13 +94,15 @@ pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> 
         return Err(Error::AlreadyVoted);
     }
 
+    // 1-address-1-vote: each voter contributes exactly 1 to the weight sum
+    // regardless of token balance (#469).
     if approve {
         let new_count = get_approve_votes(env, campaign_id)
             .checked_add(1)
             .ok_or(Error::Overflow)?;
         set_approve_votes(env, campaign_id, new_count);
         let new_weight = get_approve_weight(env, campaign_id)
-            .checked_add(balance)
+            .checked_add(1)
             .ok_or(Error::Overflow)?;
         set_approve_weight(env, campaign_id, new_weight);
     } else {
@@ -104,17 +111,16 @@ pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> 
             .ok_or(Error::Overflow)?;
         set_reject_votes(env, campaign_id, new_count);
         let new_weight = get_reject_weight(env, campaign_id)
-            .checked_add(balance)
+            .checked_add(1)
             .ok_or(Error::Overflow)?;
         set_reject_weight(env, campaign_id, new_weight);
     }
 
     set_has_voted(env, campaign_id, &voter);
 
-    let vote_weight = balance;
     env.events().publish(
         ("campaign_vote_cast", campaign_id, voter),
-        (approve, balance, vote_weight),
+        (approve, 1i128, 1i128),
     );
 
     Ok(())
@@ -174,24 +180,15 @@ pub fn verify_with_votes(env: &Env, campaign_id: u32) -> Result<(), Error> {
         return Err(Error::VotingQuorumNotMet);
     }
 
-    // Use token-weighted sums for the approval-threshold check.
-    let approve_weight = get_approve_weight(env, campaign_id);
-    let reject_weight = get_reject_weight(env, campaign_id);
-    let total_weight = approve_weight
-        .checked_add(reject_weight)
-        .ok_or(Error::Overflow)?;
-
+    // 1-address-1-vote (#469): threshold is computed from vote counts, not
+    // token balances, so flash-loaned tokens cannot inflate the approval
+    // percentage. `total_votes` is guaranteed > 0 because of the quorum
+    // check above, so division by zero is impossible.
     let threshold = effective_approval_threshold_bps(env, campaign.category);
-    let approval_bps = if total_weight > 0 {
-        // Use checked arithmetic to avoid silent overflow/truncation when
-        // approve_weight is a large i128 (e.g. whale holders on 18-decimal tokens).
-        approve_weight
-            .checked_mul(crate::BPS_DENOMINATOR as i128)
-            .and_then(|n| n.checked_div(total_weight))
-            .unwrap_or(0) as u32
-    } else {
-        0
-    };
+    let approval_bps = ((approve_votes as u64)
+        .checked_mul(crate::BPS_DENOMINATOR as u64)
+        .and_then(|n| n.checked_div(total_votes as u64))
+        .unwrap_or(0)) as u32;
     if approval_bps < threshold {
         return Err(Error::VotingThresholdNotMet);
     }

--- a/src/voting.rs
+++ b/src/voting.rs
@@ -96,6 +96,12 @@ pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> 
 
     // 1-address-1-vote: each voter contributes exactly 1 to the weight sum
     // regardless of token balance (#469).
+    //
+    // ApproveWeight/RejectWeight are deliberately kept as a mirror of the vote
+    // counts (unit weight per vote) so the legacy storage layout and the
+    // get_approve_weight/get_reject_weight queries stay consistent for
+    // existing deployments and indexers. verify_with_votes only consults the
+    // counts, so the mirror has no security impact.
     if approve {
         let new_count = get_approve_votes(env, campaign_id)
             .checked_add(1)
@@ -120,7 +126,10 @@ pub fn cast_vote(env: &Env, campaign_id: u32, voter: Address, approve: bool) -> 
 
     env.events().publish(
         ("campaign_vote_cast", campaign_id, voter),
-        (approve, 1i128, 1i128),
+        // Data shape documented in EVENT_PAYLOADS.md as
+        // (approve: bool, balance: i128, weight: i128). Balance is kept for
+        // indexers as informational signal; weight is always the unit 1.
+        (approve, balance, 1i128),
     );
 
     Ok(())
@@ -182,8 +191,10 @@ pub fn verify_with_votes(env: &Env, campaign_id: u32) -> Result<(), Error> {
 
     // 1-address-1-vote (#469): threshold is computed from vote counts, not
     // token balances, so flash-loaned tokens cannot inflate the approval
-    // percentage. `total_votes` is guaranteed > 0 because of the quorum
-    // check above, so division by zero is impossible.
+    // percentage. The unwrap_or(0) below guards the division even if
+    // total_votes were 0; with a non-zero quorum (the default, and the only
+    // value set_params allows) the quorum check above already guarantees
+    // total_votes > 0.
     let threshold = effective_approval_threshold_bps(env, campaign.category);
     let approval_bps = ((approve_votes as u64)
         .checked_mul(crate::BPS_DENOMINATOR as u64)


### PR DESCRIPTION
Closes #469

## Summary
Replace token-weighted voting with a **1-address-1-vote** model to close the flash-loan attack vector where an attacker borrows a large token balance, votes with inflated weight, and returns the tokens before verification.

## What Changed
- **`cast_vote`**: Each vote now contributes exactly `1` to the weight sum instead of the voter's live token balance. The token-holder gate (`min_voting_balance`) is preserved — you still need tokens to vote, but your balance doesn't affect your voting power.
- **`verify_with_votes`**: Threshold calculation now uses vote **counts** (`approve_votes` / `reject_votes`) instead of token **weights**. This is safe because the quorum check already guarantees `total_votes > 0`.
- **Backward compat**: `approve_weight` and `reject_weight` storage keys are still incremented (by 1 per vote) so existing campaigns with stored voting state remain valid.

## Design Decision
Three options were considered from the issue: snapshot at creation, minimum holding period, or 1-address-1-vote. **1-address-1-vote** was chosen because it's the simplest, most gas-efficient fix that fully eliminates the flash-loan vector without requiring expensive on-chain iteration of all token holders at campaign creation time.

## Acceptance Criteria
- [x] `cast_vote` no longer uses live balance for voting weight
- [x] `verify_with_votes` threshold immune to flash-loan inflation
- [x] Token-holder gate preserved (must hold >= `min_voting_balance`)
- [x] All tests pass (393/395, 2 pre-existing unrelated failures in `test_campaign_update`)
- [x] Clippy clean, formatting clean
- [x] Proptests updated for 1-address-1-vote invariant

## Test Output
```
test result: ok. 393 passed; 2 failed (pre-existing in test_campaign_update)
```

## Follow-ups (out of scope)
- Consider removing `approve_weight`/`reject_weight` storage entirely since they now equal vote counts (backward-compat cleanup)
- Update `EVENT_PAYLOADS.md` to reflect changed event shape

## Security Note
This fix prevents flash-loan governance attacks. The 1-address-1-vote model is Sybil-resistant only to the extent that obtaining token balances across many addresses costs real capital. The `min_voting_balance` admin parameter can be raised to increase this cost.
