### PR TITLE
fix: block update_campaign_description after verification (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `update_campaign_description` now blocks edits once `is_verified == true`, preventing bait-and-switch after admin or community approval (#440). This makes it consistent with `update_campaign`, which already enforced this guard.
+
 - `cancel_campaign` now rejects with `GoalMetCancellationNotAllowed` when `amount_raised >= funding_goal` and funds have not yet been withdrawn, preventing rug-pull-adjacent behaviour where a creator could cancel after reaching the goal and force all contributors to self-serve refunds (#164).
 
 - `update_campaign_description` now blocks edits once `amount_raised > 0`, preventing bait-and-switch after contributions (#166).

--- a/src/campaigns/update.rs
+++ b/src/campaigns/update.rs
@@ -55,6 +55,10 @@ pub(crate) fn update_campaign(
     Ok(())
 }
 
+/// Updates only the description of a campaign.
+///
+/// Blocked after verification (issue #416: verified content must match
+/// published content) — consistent with `update_campaign`.
 pub(crate) fn update_campaign_description(
     env: &Env,
     campaign_id: u32,
@@ -62,6 +66,9 @@ pub(crate) fn update_campaign_description(
 ) -> Result<(), Error> {
     let mut campaign = get_creator_campaign(env, campaign_id)?;
     require_not_paused(env)?;
+
+    // Fix #416: verification freezes title and description.
+    require_unverified_campaign(&campaign)?;
 
     require_active_campaign(&campaign)?;
     if description.len() < crate::CAMPAIGN_DESCRIPTION_MIN_LEN

--- a/src/tests/test_campaign_update.rs
+++ b/src/tests/test_campaign_update.rs
@@ -59,10 +59,11 @@ fn test_update_campaign_emits_title_and_description() {
 
     let events = env.events().all();
     let last_event = events.last().unwrap();
-    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    let payload: (String, String, String, String) =
+        soroban_sdk::FromVal::from_val(&env, &last_event.2);
 
-    assert_eq!(payload.0, new_title);
-    assert_eq!(payload.1, new_desc);
+    assert_eq!(payload.2, new_title);
+    assert_eq!(payload.3, new_desc);
 }
 
 #[test]
@@ -94,9 +95,10 @@ fn test_update_campaign_event_tracks_latest_description() {
 
     let events = env.events().all();
     let last_event = events.last().unwrap();
-    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
-    assert_eq!(payload.0, String::from_str(&env, "Title V3"));
-    assert_eq!(payload.1, String::from_str(&env, "Description V3"));
+    let payload: (String, String, String, String) =
+        soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(payload.2, String::from_str(&env, "Title V3"));
+    assert_eq!(payload.3, String::from_str(&env, "Description V3"));
 }
 
 #[test]
@@ -156,7 +158,6 @@ fn test_update_campaign_description_success() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     let new_desc = String::from_str(&env, "Updated description with more detail");
     assert!(client
@@ -183,7 +184,6 @@ fn test_update_campaign_description_rejects_cancelled() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
     client.cancel_campaign(&campaign_id);
 
     let res =
@@ -206,7 +206,6 @@ fn test_update_campaign_description_rejects_empty() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     let res = client.try_update_campaign_description(&campaign_id, &String::from_str(&env, ""));
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
@@ -217,6 +216,76 @@ fn test_update_campaign_description_not_found() {
     let (env, _, _, _, _, _, _, client) = setup_env();
     let res = client.try_update_campaign_description(&999, &String::from_str(&env, "Some desc"));
     assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_update_campaign_description_blocks_after_admin_verification() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let orig_desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        orig_desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    // Fix #440: update_campaign_description must be blocked after admin
+    // verification, preventing bait-and-switch after admin approval.
+    let res = client.try_update_campaign_description(
+        &campaign_id,
+        &String::from_str(&env, "Fraudulent Description"),
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.description, orig_desc);
+}
+
+#[test]
+fn test_update_campaign_description_blocks_after_community_verification() {
+    let (env, _admin, creator, contributor1, contributor2, _, token_admin, client) = setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let orig_desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        orig_desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &true);
+    client.verify_campaign_with_votes(&campaign_id);
+    assert!(client.get_campaign(&campaign_id).is_verified);
+
+    // Fix #440: update_campaign_description must be blocked after community
+    // verification, preventing bait-and-switch after community approval.
+    let res = client.try_update_campaign_description(
+        &campaign_id,
+        &String::from_str(&env, "Fraudulent Description"),
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.description, orig_desc);
 }
 
 #[test]
@@ -235,7 +304,6 @@ fn test_campaign_ownership_transfer_flow() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     client.initiate_campaign_transfer(&campaign_id, &new_creator);
     let campaign = client.get_campaign(&campaign_id);
@@ -438,10 +506,15 @@ fn test_update_description_after_contribution() {
     client.contribute(&campaign_id, &contributor1, &500);
 
     let new_desc = String::from_str(&env, "New Description After Contribution");
-    client.update_campaign_description(&campaign_id, &new_desc);
+    let res = client.try_update_campaign_description(&campaign_id, &new_desc);
+
+    // update_campaign_description is blocked after verification
+    // (CampaignAlreadyVerified takes precedence over the amount_raised > 0
+    // check since it's checked first).
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
 
     let campaign = client.get_campaign(&campaign_id);
-    assert_eq!(campaign.description, new_desc);
+    assert_ne!(campaign.description, new_desc);
 }
 
 #[test]

--- a/src/tests/test_campaigns.rs
+++ b/src/tests/test_campaigns.rs
@@ -834,7 +834,6 @@ fn test_update_campaign_description_success() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     let new_desc = String::from_str(&env, "Updated description with more detail");
     assert!(client
@@ -863,7 +862,6 @@ fn test_update_campaign_description_emits_metadata_updated_with_unchanged_title(
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     let new_desc = String::from_str(&env, "Updated description with more detail");
     client.update_campaign_description(&campaign_id, &new_desc);
@@ -895,7 +893,6 @@ fn test_update_campaign_description_rejects_cancelled() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
     client.cancel_campaign(&campaign_id);
 
     let res =
@@ -918,7 +915,6 @@ fn test_update_campaign_description_rejects_empty() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     let res = client.try_update_campaign_description(&campaign_id, &String::from_str(&env, ""));
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
@@ -929,6 +925,76 @@ fn test_update_campaign_description_not_found() {
     let (env, _, _, _, _, _, _, client) = setup_env();
     let res = client.try_update_campaign_description(&999, &String::from_str(&env, "Some desc"));
     assert_eq!(res.unwrap_err().unwrap(), Error::CampaignNotFound);
+}
+
+#[test]
+fn test_update_campaign_description_blocks_after_admin_verification() {
+    let (env, _admin, creator, _, _, _, _, client) = setup_env();
+
+    let orig_desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        orig_desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    // Fix #440: update_campaign_description must be blocked after admin
+    // verification, preventing bait-and-switch after admin approval.
+    let res = client.try_update_campaign_description(
+        &campaign_id,
+        &String::from_str(&env, "Fraudulent Description"),
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.description, orig_desc);
+}
+
+#[test]
+fn test_update_campaign_description_blocks_after_community_verification() {
+    let (env, _admin, creator, contributor1, contributor2, _, token_admin, client) = setup_env();
+    let voter3 = Address::generate(&env);
+
+    token_admin.mint(&contributor1, &100);
+    token_admin.mint(&contributor2, &100);
+    token_admin.mint(&voter3, &100);
+
+    let orig_desc = String::from_str(&env, "Original Description");
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Original Title"),
+        orig_desc.clone(),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+
+    client.vote_on_campaign(&campaign_id, &contributor1, &true);
+    client.vote_on_campaign(&campaign_id, &contributor2, &true);
+    client.vote_on_campaign(&campaign_id, &voter3, &true);
+    client.verify_campaign_with_votes(&campaign_id);
+    assert!(client.get_campaign(&campaign_id).is_verified);
+
+    // Fix #440: update_campaign_description must be blocked after community
+    // verification, preventing bait-and-switch after community approval.
+    let res = client.try_update_campaign_description(
+        &campaign_id,
+        &String::from_str(&env, "Fraudulent Description"),
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
+
+    let campaign = client.get_campaign(&campaign_id);
+    assert_eq!(campaign.description, orig_desc);
 }
 
 #[test]
@@ -947,7 +1013,6 @@ fn test_campaign_ownership_transfer_flow() {
         0,
         0i128,
     ));
-    let _ = client.try_verify_campaign(&campaign_id);
 
     client.initiate_campaign_transfer(&campaign_id, &new_creator);
     let campaign = client.get_campaign(&campaign_id);
@@ -1150,10 +1215,15 @@ fn test_update_description_after_contribution() {
     client.contribute(&campaign_id, &contributor1, &500);
 
     let new_desc = String::from_str(&env, "New Description After Contribution");
-    client.update_campaign_description(&campaign_id, &new_desc);
+    let res = client.try_update_campaign_description(&campaign_id, &new_desc);
+
+    // update_campaign_description is blocked after verification
+    // (CampaignAlreadyVerified takes precedence over the amount_raised > 0
+    // check since it's checked first).
+    assert_eq!(res.unwrap_err().unwrap(), Error::CampaignAlreadyVerified);
 
     let campaign = client.get_campaign(&campaign_id);
-    assert_eq!(campaign.description, new_desc);
+    assert_ne!(campaign.description, new_desc);
 }
 
 #[test]


### PR DESCRIPTION
Resolves #440.

**Problem:** `update_campaign_description` did not call `require_unverified_campaign`, allowing a creator to change the description of a verified-but-uncontributed campaign — the same bait-and-switch vulnerability that `update_campaign` already guards against.

**Fix:** Added `require_unverified_campaign(&campaign)?` to `update_campaign_description`, making it consistent with `update_campaign`.

**Changes:**
- `src/campaigns/update.rs`: Added `require_unverified_campaign` guard to `update_campaign_description`
- `src/tests/test_campaign_update.rs`: Updated tests expecting old behavior; added negative tests for admin/community verification blocking; fixed pre-existing test failures (4-tuple event unpacking)
- `src/tests/test_campaigns.rs`: Same test updates for duplicate tests
- `CHANGELOG.md`: Added changelog entry

All CI checks pass: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --features testutils` (401 passed), `cargo build --target wasm32-unknown-unknown --release`.