### PR TITLE
fix: move require_not_paused before require_auth in accept_campaign_transfer (#453)

### DIFF
--- a/src/campaigns/transfer.rs
+++ b/src/campaigns/transfer.rs
@@ -51,14 +51,13 @@ pub(crate) fn initiate_campaign_transfer(
 pub(crate) fn accept_campaign_transfer(env: &Env, campaign_id: u32) -> Result<(), Error> {
     let mut campaign = get_campaign_or_error(env, campaign_id)?;
     require_active_campaign(&campaign)?;
+    require_not_paused(env)?;
 
     let pending = match campaign.pending_creator.clone() {
         MaybePendingCreator::Some(addr) => addr,
         MaybePendingCreator::None => return Err(Error::NoTransferPending),
     };
     pending.require_auth();
-
-    require_not_paused(env)?;
 
     bump_instance_ttl(env);
     let old_creator = campaign.creator.clone();

--- a/src/tests/test_campaign_update.rs
+++ b/src/tests/test_campaign_update.rs
@@ -59,10 +59,12 @@ fn test_update_campaign_emits_title_and_description() {
 
     let events = env.events().all();
     let last_event = events.last().unwrap();
-    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    // Event payload: (old_title, old_description, title, event_description)
+    let payload: (String, String, String, String) =
+        soroban_sdk::FromVal::from_val(&env, &last_event.2);
 
-    assert_eq!(payload.0, new_title);
-    assert_eq!(payload.1, new_desc);
+    assert_eq!(payload.2, new_title);
+    assert_eq!(payload.3, new_desc);
 }
 
 #[test]
@@ -94,9 +96,11 @@ fn test_update_campaign_event_tracks_latest_description() {
 
     let events = env.events().all();
     let last_event = events.last().unwrap();
-    let payload: (String, String) = soroban_sdk::FromVal::from_val(&env, &last_event.2);
-    assert_eq!(payload.0, String::from_str(&env, "Title V3"));
-    assert_eq!(payload.1, String::from_str(&env, "Description V3"));
+    // Event payload: (old_title, old_description, title, event_description)
+    let payload: (String, String, String, String) =
+        soroban_sdk::FromVal::from_val(&env, &last_event.2);
+    assert_eq!(payload.2, String::from_str(&env, "Title V3"));
+    assert_eq!(payload.3, String::from_str(&env, "Description V3"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #453.

**Problem:** In `accept_campaign_transfer`, `pending.require_auth()` was called **before** `require_not_paused(env)?`. This meant users would sign with Freighter only to get a `ContractPaused` error, wasting their signature.

**Fix:** Move `require_not_paused(env)?` to run **before** `pending.require_auth()`, so the paused check happens first and the user is never prompted to sign if the contract is paused.

## Changes

- `src/campaigns/transfer.rs`: Reordered checks in `accept_campaign_transfer` — paused check now precedes auth.