### PR TITLE
Fix #437: Check require_not_paused before pending.require_auth()

### DIFF
--- a/src/campaigns/transfer.rs
+++ b/src/campaigns/transfer.rs
@@ -51,14 +51,13 @@ pub(crate) fn initiate_campaign_transfer(
 pub(crate) fn accept_campaign_transfer(env: &Env, campaign_id: u32) -> Result<(), Error> {
     let mut campaign = get_campaign_or_error(env, campaign_id)?;
     require_active_campaign(&campaign)?;
+    require_not_paused(env)?;
 
     let pending = match campaign.pending_creator.clone() {
         MaybePendingCreator::Some(addr) => addr,
         MaybePendingCreator::None => return Err(Error::NoTransferPending),
     };
     pending.require_auth();
-
-    require_not_paused(env)?;
 
     bump_instance_ttl(env);
     let old_creator = campaign.creator.clone();


### PR DESCRIPTION
## Summary

In `src/campaigns/transfer.rs`, `accept_campaign_transfer` was calling `require_not_paused` **after** `pending.require_auth()`, causing users to waste a signature when the contract is paused.

## Changes

- Moved `require_not_paused(env)?` before `pending.require_auth()` so users are informed the contract is paused before being asked to sign.

Close #437
