### PR TITLE
fix(#445): replace unchecked i128/u32 additions with checked_add to prevent overflow

### DIFF
--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -23,7 +23,10 @@ fn check_contribution_caps(
     amount: i128,
 ) -> Result<(), Error> {
     if campaign.max_contribution_per_user > 0
-        && current_lifetime_contribution + amount > campaign.max_contribution_per_user
+        && current_lifetime_contribution
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?
+            > campaign.max_contribution_per_user
     {
         return Err(Error::ContributionCapExceeded);
     }
@@ -97,19 +100,40 @@ fn update_contribution_accounting(
     current: i128,
     lifetime: i128,
     amount: i128,
-) {
-    campaign.amount_raised += amount;
-    campaign.effective_amount_raised += amount;
+) -> Result<(), Error> {
+    campaign.amount_raised = campaign
+        .amount_raised
+        .checked_add(amount)
+        .ok_or(Error::Overflow)?;
+    campaign.effective_amount_raised = campaign
+        .effective_amount_raised
+        .checked_add(amount)
+        .ok_or(Error::Overflow)?;
     set_campaign(env, campaign_id, campaign);
-    set_contribution(env, campaign_id, contributor, current + amount);
-    set_lifetime_contribution(env, campaign_id, contributor, lifetime + amount);
+    set_contribution(
+        env,
+        campaign_id,
+        contributor,
+        current.checked_add(amount).ok_or(Error::Overflow)?,
+    );
+    set_lifetime_contribution(
+        env,
+        campaign_id,
+        contributor,
+        lifetime.checked_add(amount).ok_or(Error::Overflow)?,
+    );
 
     if lifetime == 0 {
         increment_contributor_count(env, campaign_id);
     }
 
     let total_raised = get_total_raised_global(env);
-    set_total_raised_global(env, total_raised + amount);
+    set_total_raised_global(
+        env,
+        total_raised.checked_add(amount).ok_or(Error::Overflow)?,
+    );
+
+    Ok(())
 }
 
 pub(crate) fn contribute(
@@ -145,7 +169,7 @@ pub(crate) fn contribute(
     check_contribution_caps(&campaign, lifetime, amount)?;
 
     if let Some(cap) = get_personal_cap(env, campaign_id, &contributor) {
-        if current + amount > cap {
+        if current.checked_add(amount).ok_or(Error::Overflow)? > cap {
             return Err(Error::ContributionCapExceeded);
         }
     }
@@ -161,7 +185,7 @@ pub(crate) fn contribute(
         current,
         lifetime,
         amount,
-    );
+    )?;
 
     let client = token_client(env);
     client.transfer(&contributor, &env.current_contract_address(), &amount);
@@ -217,7 +241,7 @@ pub(crate) fn batch_contribute(
         check_contribution_caps(&campaign, lifetime, amount)?;
 
         if let Some(cap) = get_personal_cap(env, campaign_id, &contributor) {
-            if current + amount > cap {
+            if current.checked_add(amount).ok_or(Error::Overflow)? > cap {
                 return Err(Error::ContributionCapExceeded);
             }
         }
@@ -232,7 +256,7 @@ pub(crate) fn batch_contribute(
             current,
             lifetime,
             amount,
-        );
+        )?;
 
         total = total.checked_add(amount).ok_or(Error::Overflow)?;
 

--- a/src/revenue.rs
+++ b/src/revenue.rs
@@ -35,7 +35,11 @@ pub(crate) fn deposit_revenue(env: &Env, campaign_id: u32, amount: i128) -> Resu
     bump_instance_ttl(env);
 
     let current_pool = get_revenue_pool(env, campaign_id);
-    set_revenue_pool(env, campaign_id, current_pool + amount);
+    set_revenue_pool(
+        env,
+        campaign_id,
+        current_pool.checked_add(amount).ok_or(Error::Overflow)?,
+    );
 
     let token_addr = get_token(env);
     let client = token::Client::new(env, &token_addr);
@@ -103,8 +107,9 @@ pub(crate) fn claim_revenue(
     let is_first_claim = already_claimed == 0;
     let claimants_so_far = get_contributor_revenue_claimants(env, campaign_id);
     let total_contributors = get_contributor_count(env, campaign_id);
-    let is_last_claimant =
-        is_first_claim && total_contributors > 0 && claimants_so_far + 1 >= total_contributors;
+    let is_last_claimant = is_first_claim
+        && total_contributors > 0
+        && claimants_so_far.checked_add(1).ok_or(Error::Overflow)? >= total_contributors;
 
     let distributed_so_far = get_contributor_revenue_distributed(env, campaign_id);
     if is_last_claimant {
@@ -129,14 +134,31 @@ pub(crate) fn claim_revenue(
 
     // Update state before the token transfer (CEI pattern) so that a
     // malicious token contract cannot re-enter and double-claim (#557).
-    set_revenue_claimed(env, campaign_id, &contributor, already_claimed + claimable);
+    set_revenue_claimed(
+        env,
+        campaign_id,
+        &contributor,
+        already_claimed
+            .checked_add(claimable)
+            .ok_or(Error::Overflow)?,
+    );
 
     // Track the running sum paid out to contributors, and the count of
     // distinct contributors who have claimed at least once, so future claims
     // can detect the last claimant (#526).
-    set_contributor_revenue_distributed(env, campaign_id, distributed_so_far + claimable);
+    set_contributor_revenue_distributed(
+        env,
+        campaign_id,
+        distributed_so_far
+            .checked_add(claimable)
+            .ok_or(Error::Overflow)?,
+    );
     if is_first_claim {
-        set_contributor_revenue_claimants(env, campaign_id, claimants_so_far + 1);
+        set_contributor_revenue_claimants(
+            env,
+            campaign_id,
+            claimants_so_far.checked_add(1).ok_or(Error::Overflow)?,
+        );
     }
 
     // Token transfer happens after all state updates (CEI pattern).
@@ -183,7 +205,13 @@ pub(crate) fn claim_creator_revenue(env: &Env, campaign_id: u32) -> Result<(), E
 
     // Update state before the token transfer (CEI pattern) so that a
     // malicious token contract cannot re-enter and double-claim (#557).
-    set_creator_revenue_claimed(env, campaign_id, already_claimed + claimable);
+    set_creator_revenue_claimed(
+        env,
+        campaign_id,
+        already_claimed
+            .checked_add(claimable)
+            .ok_or(Error::Overflow)?,
+    );
 
     // Token transfer happens after all state updates (CEI pattern).
     let client = token_client(env);


### PR DESCRIPTION
## Summary
Closes #445

In `src/contributions.rs` and `src/revenue.rs`, several unchecked `i128` and `u32` additions could silently overflow on high-balance tokens (e.g., 18-decimal tokens with large supplies). This PR replaces all of them with `checked_add(...).ok_or(Error::Overflow)?` to ensure safe overflow handling.

**Note:** `verify_with_votes` in `src/voting.rs` already uses `checked_add` for `total_votes` and `total_weight` (fixed in prior work). This PR extends the same pattern to the remaining locations.

## Changes

### `src/contributions.rs` (46 lines changed)
- **`check_contribution_caps`**: cap comparison now uses `checked_add`
- **`update_contribution_accounting`**: return type changed from `()` to `Result<(), Error>`; 5 additions (amount_raised, effective_amount_raised, contribution, lifetime, total_raised) all use checked arithmetic
- **`contribute()`**: personal cap check uses `checked_add`
- **`batch_contribute()`**: personal cap check uses `checked_add`

### `src/revenue.rs` (31 lines changed)
- **`deposit_revenue`**: pool accumulation uses `checked_add`
- **`claim_revenue`**: claimed amount and distributed accumulator use `checked_add`
- **`claim_creator_revenue`**: claimed amount uses `checked_add`

## Security Considerations
- Follows the same pattern already used in `cast_vote` for consistency
- CEI (Checks-Effects-Interactions) pattern preserved — state updates happen before external token transfers
- `Error::Overflow` variant (discriminant 30) already exists in `src/errors.rs`

## Testing
- All existing tests should continue to pass
- Overflow behavior is deterministic: large values return `Error::Overflow` instead of silently wrapping
