### PR TITLE
ci(#471): enforce cargo audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,14 @@ jobs:
           targets: wasm32-unknown-unknown
       - run: cargo test --features testutils
       - run: cargo build --target wasm32-unknown-unknown --release
+
+  # Issue #471: audit the dependency tree for known vulnerabilities on every
+  # PR/push. Fails the build if any advisory applies to a locked version.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
 
   # Issue #471: audit the dependency tree for known vulnerabilities on every
   # PR/push. Fails the build if any advisory applies to a locked version.
+  #
+  # Two advisories are ignored with justification:
+  #   - RUSTSEC-2024-0344 (curve25519-dalek < 4.1.3, timing side-channel):
+  #     soroban-env-host 20.1.0 pins curve25519-dalek to exactly 4.1.1, and
+  #     this project pins soroban-sdk to exactly 20.1.0. The patched version
+  #     is not installable without upgrading the SDK, which is out of scope.
+  #   - RUSTSEC-2026-0009 (time < 0.3.47, stack-exhaustion DoS): time is only
+  #     reachable as an optional dependency of serde_with behind its disabled
+  #     time_0_3 feature; it is never compiled into the dependency graph.
   audit:
     runs-on: ubuntu-latest
     steps:
@@ -48,4 +57,4 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-audit
-      - run: cargo audit
+      - run: cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,13 @@ cargo fmt --check
 cargo clippy --all-targets --features testutils -- -D warnings
 cargo test --features testutils
 stellar contract build
-cargo audit
+cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009
 ```
 
-All five must pass. `cargo audit` (install with `cargo install cargo-audit`) scans the dependency tree for known security advisories and fails if any apply to a locked version.
+All five must pass. `cargo audit` (install with `cargo install cargo-audit`) scans the dependency tree for known security advisories and fails if any apply to a locked version. The two `--ignore` flags are required and mirror the CI gate (see `.github/workflows/ci.yml`); both advisories are documented there:
+
+- `RUSTSEC-2024-0344` (`curve25519-dalek < 4.1.3`): `soroban-env-host 20.1.0` pins this crate to exactly `4.1.1`, which is in turn fixed by the pinned `soroban-sdk =20.1.0`. The patched version is not installable without upgrading the SDK.
+- `RUSTSEC-2026-0009` (`time < 0.3.47`): `time` only enters the graph as an optional dependency of `serde_with` behind its disabled `time_0_3` feature, so the vulnerable code is never compiled.
 
 ## Branches
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,10 @@ cargo fmt --check
 cargo clippy --all-targets --features testutils -- -D warnings
 cargo test --features testutils
 stellar contract build
+cargo audit
 ```
 
-All four must pass.
+All five must pass. `cargo audit` (install with `cargo install cargo-audit`) scans the dependency tree for known security advisories and fails if any apply to a locked version.
 
 ## Branches
 


### PR DESCRIPTION
## Summary

Fixes #471

The fmt and clippy gates were already added to CI (#406) along with the error-discriminant fix they would have caught. The missing piece from this issue was **`cargo audit`**.

Changes:
- Add a dedicated `audit` job to `.github/workflows/ci.yml` that runs `cargo audit` (prebuilt binary via `taiki-e/install-action`) and fails on any advisory applicable to the lockfile.
- Two advisories are explicitly ignored with inline justification:
  - `RUSTSEC-2024-0344` (`curve25519-dalek < 4.1.3`): exact-pinned (`=4.1.1`) by `soroban-env-host 20.1.0`, itself fixed by the pinned `soroban-sdk =20.1.0`. The patched version is not installable without a SDK upgrade (out of scope).
  - `RUSTSEC-2026-0009` (`time < 0.3.47`): `time` only enters the graph as an optional dependency of `serde_with` behind its disabled `time_0_3` feature — never compiled (confirmed via `cargo tree -i time` → "nothing to print").
- Document `cargo audit` in `CONTRIBUTING.md` (now five enforced checks, not four), including the ignore flags and their rationale.

Note: `IMPLEMENTATION_SUMMARY.md` does not exist in this repo, so there was nothing to correct there.

## CI status on this PR

- **`audit`: passing** (verified — the only failure previously was the two advisories above, now ignored with justification).
- `fmt`/`clippy`/`test` fail due to non-compiling code merged in #618 (duplicate contractimpl blocks, stray `src/campaigns.rs`). This is unrelated to #471 and is being resolved separately in PR #729; once #729 lands, this branch will be rebased so those checks go green.
