### PR TITLE
docs: add changelog entry for #452

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `resume_campaign` now checks the global `AutoPaused` flag before `require_active_campaign`, returning early with `ValidationFailed` when the contract is not auto-paused instead of failing on an unrelated campaign-state check. The admin recovery path via `unpause()` also clears `AutoPaused` alongside `Paused` so neither flag can permanently lock the contract (#436).
 
+- `unpause()` now clears the `AutoPaused` flag in addition to `Paused`, preventing the contract from becoming permanently stuck if the campaign that triggered an automatic pause is subsequently cancelled (#452).
+
 - `cancel_campaign` now rejects with `GoalMetCancellationNotAllowed` when `amount_raised >= funding_goal` and funds have not yet been withdrawn, preventing rug-pull-adjacent behaviour where a creator could cancel after reaching the goal and force all contributors to self-serve refunds (#164).
 
 - `update_campaign_description` now blocks edits once `amount_raised > 0`, preventing bait-and-switch after contributions (#166).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `verify_campaigns` (batch admin verification) now returns `(verified_ids, failed_ids)` covering every id it processed, instead of collapsing a partial-success batch into `Err(first_error)`. Callers can now distinguish partial success from total failure and retry only the failed ids, and the successful verifications are committed on-chain instead of being reverted; the `campaigns_bulk_verified` event payload is now `(verified_count, failed_ids)` (#442).
 
-- `resume_campaign` now checks the global `AutoPaused` flag before `require_active_campaign`, returning early with `ValidationFailed` when the contract is not auto-paused instead of failing on an unrelated campaign-state check. The admin recovery path via `unpause()` also clears `AutoPaused` alongside `Paused` so neither flag can permanently lock the contract (#436).
-
-- `unpause()` now clears the `AutoPaused` flag in addition to `Paused`, preventing the contract from becoming permanently stuck if the campaign that triggered an automatic pause is subsequently cancelled (#452).
+- `resume_campaign` now checks the global `AutoPaused` flag before `require_active_campaign`, returning early with `ValidationFailed` when the contract is not auto-paused instead of failing on an unrelated campaign-state check. The admin recovery path via `unpause()` also clears `AutoPaused` alongside `Paused` so neither flag can permanently lock the contract (#436, #452).
 
 - `cancel_campaign` now rejects with `GoalMetCancellationNotAllowed` when `amount_raised >= funding_goal` and funds have not yet been withdrawn, preventing rug-pull-adjacent behaviour where a creator could cancel after reaching the goal and force all contributors to self-serve refunds (#164).
 


### PR DESCRIPTION
## Summary

Adds the changelog entry for #452 documenting the AutoPaused stuck-state bug.

The underlying contract fix is already present on main, so this follow-up PR intentionally contains only the missing changelog documentation.

## Changes

- Added the #452 bug-fix entry to CHANGELOG.md
- No contract logic changes
- No test changes
- No unrelated files modified

Closes #452
