### PR TITLE
fix: reject set_personal_cap below lifetime_contribution (#441)

### DIFF
--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -333,6 +333,10 @@ pub(crate) fn set_personal_cap_fn(
     if amount < 0 {
         return Err(Error::ValidationFailed);
     }
+    let lifetime = get_lifetime_contribution(env, campaign_id, &contributor);
+    if amount < lifetime {
+        return Err(Error::ValidationFailed);
+    }
     let campaign = get_campaign_or_error(env, campaign_id)?;
     require_active_campaign(&campaign)?;
     if campaign.max_contribution_per_user > 0 && amount > campaign.max_contribution_per_user {

--- a/src/tests/test_regressions.rs
+++ b/src/tests/test_regressions.rs
@@ -273,6 +273,67 @@ fn test_set_personal_cap_cannot_exceed_max_contribution_per_user() {
     assert_eq!(res2.unwrap_err().unwrap(), Error::ValidationFailed);
 }
 
+// ── #441 set_personal_cap below lifetime_contribution rejected ──
+#[test]
+fn test_set_personal_cap_below_lifetime_contribution_rejected() {
+    let (env, _admin, creator, contributor, _, _token, token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "T"),
+        description: String::from_str(&env, "D"),
+        funding_goal: 10_000,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    });
+
+    token_admin.mint(&contributor, &10_000);
+    client.contribute(&campaign_id, &contributor, &1000);
+    assert_eq!(
+        client.get_lifetime_contribution(&campaign_id, &contributor),
+        1000
+    );
+
+    let res = client.try_set_personal_cap(&campaign_id, &contributor, &500);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+
+    let res = client.try_set_personal_cap(&campaign_id, &contributor, &1000);
+    assert!(res.is_ok());
+
+    let res = client.try_set_personal_cap(&campaign_id, &contributor, &2000);
+    assert!(res.is_ok());
+}
+
+// ── #441 boundary: cap == lifetime blocks future contributions ──
+#[test]
+fn test_set_personal_cap_equal_lifetime_blocks_further_contributions() {
+    let (env, _admin, creator, contributor, _, _token, token_admin, client) = setup_env();
+
+    let campaign_id = client.create_campaign(&CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "T"),
+        description: String::from_str(&env, "D"),
+        funding_goal: 10_000,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    });
+
+    token_admin.mint(&contributor, &10_000);
+    client.contribute(&campaign_id, &contributor, &1000);
+
+    let res = client.try_set_personal_cap(&campaign_id, &contributor, &1000);
+    assert!(res.is_ok());
+
+    let res = client.try_contribute(&campaign_id, &contributor, &1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ContributionCapExceeded);
+}
+
 // ── #354 vote weight checked addition ──
 #[test]
 fn test_vote_weight_overflow_fails() {

--- a/src/tests/test_regressions.rs
+++ b/src/tests/test_regressions.rs
@@ -291,6 +291,7 @@ fn test_set_personal_cap_below_lifetime_contribution_rejected() {
     });
 
     token_admin.mint(&contributor, &10_000);
+    client.verify_campaign(&campaign_id);
     client.contribute(&campaign_id, &contributor, &1000);
     assert_eq!(
         client.get_lifetime_contribution(&campaign_id, &contributor),
@@ -325,6 +326,7 @@ fn test_set_personal_cap_equal_lifetime_blocks_further_contributions() {
     });
 
     token_admin.mint(&contributor, &10_000);
+    client.verify_campaign(&campaign_id);
     client.contribute(&campaign_id, &contributor, &1000);
 
     let res = client.try_set_personal_cap(&campaign_id, &contributor, &1000);


### PR DESCRIPTION
PR #441: Reject personal cap below lifetime_contribution

## Problem

`set_personal_cap_fn` did not validate the new cap against the caller's existing `lifetime_contribution`. A contributor could set their cap to 1 stroop after contributing 1000 XLM, permanently blocking further contributions with no way to raise the cap again.

## Fix

Added a validation check in `set_personal_cap_fn` (`src/contributions.rs`) that rejects any personal cap value below the caller's current `lifetime_contribution`:

```rust
let lifetime = get_lifetime_contribution(env, campaign_id, &contributor);
if amount < lifetime {
    return Err(Error::ValidationFailed);
}
```

Setting a cap **equal** to `lifetime_contribution` is intentionally allowed — it blocks future contributions without stranding anything, and the contributor can always set a higher cap later.

## Tests

Two regression tests in `src/tests/test_regressions.rs`:

1. **`test_set_personal_cap_below_lifetime_contribution_rejected`** — contributes 1000, asserts cap=500 is rejected, cap=1000 is accepted, cap=2000 is accepted.
2. **`test_set_personal_cap_equal_lifetime_blocks_further_contributions`** — contributes 1000, sets cap to 1000 (equal to lifetime), asserts a subsequent contribution of 1 stroop is rejected with `ContributionCapExceeded`. This documents the boundary behavior as intentional.

## Diff

```
 src/contributions.rs          |  4 ++++
 src/tests/test_regressions.rs | 61 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 65 insertions(+)
```

Closes #441 