### PR TITLE
fix(campaigns): run require_auth before funds_withdrawn guard in withdraw_reserve

### DIFF
--- a/src/campaigns/withdraw.rs
+++ b/src/campaigns/withdraw.rs
@@ -137,6 +137,8 @@ pub(crate) fn withdraw_reserve(env: &Env, campaign_id: u32) -> Result<(), Error>
 
     let campaign = get_campaign_or_error(env, campaign_id)?;
 
+    campaign.creator.require_auth();
+
     // Defense-in-depth: only release reserve on campaigns that have
     // actually withdrawn funds. A migration-planted reserve on a
     // non-withdrawn campaign must not be drainable.
@@ -149,8 +151,6 @@ pub(crate) fn withdraw_reserve(env: &Env, campaign_id: u32) -> Result<(), Error>
     if !campaign.funds_withdrawn {
         return Err(Error::ValidationFailed);
     }
-
-    campaign.creator.require_auth();
 
     // Update state before the token transfer (CEI pattern) so that a
     // malicious token contract cannot re-enter and double-claim (#557).


### PR DESCRIPTION
Follow-up to the discussion on #727 (which was superseded by #693).

## Why

#693 merged the `funds_withdrawn` guard in `withdraw_reserve`, but it placed the guard **before** `campaign.creator.require_auth()`. Everywhere else in this file, auth is the first gate after loading the campaign. This PR simply swaps that order for consistency — no behavior change to the guard itself.

## Change

- `src/campaigns/withdraw.rs` — move `campaign.creator.require_auth()` above the `funds_withdrawn` guard in `withdraw_reserve` (2-line move, comment untouched).

No test changes: the merged regression test from #693 already covers the guard, and this reorder does not alter the guard's behavior.

Closes #443