### PR TITLE
fix: withdraw_funds uses effective_amount_raised (#514)

### DIFF
--- a/src/campaigns/withdraw.rs
+++ b/src/campaigns/withdraw.rs
@@ -31,7 +31,7 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
     if campaign.funds_withdrawn {
         return Err(Error::FundsAlreadyWithdrawn);
     }
-    if campaign.amount_raised == 0 {
+    if campaign.effective_amount_raised == 0 {
         return Err(Error::NoFundsToWithdraw);
     }
 
@@ -46,14 +46,14 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
         .fee_override
         .unwrap_or_else(|| get_platform_fee(env));
     // Ceiling division: ceil(a / b) = (a + b - 1) / b. Use checked arithmetic so
-    // a pathological amount_raised yields Error::Overflow rather than a panic (#408).
+    // a pathological effective_amount_raised yields Error::Overflow rather than a panic (#408).
     let fee_amount = campaign
-        .amount_raised
+        .effective_amount_raised
         .checked_mul(platform_fee as i128)
         .and_then(|n| n.checked_add(crate::BPS_CEIL_OFFSET))
         .ok_or(Error::Overflow)?
         / crate::BPS_DENOMINATOR as i128;
-    let total_after_fee = campaign.amount_raised - fee_amount;
+    let total_after_fee = campaign.effective_amount_raised - fee_amount;
 
     // Use per-campaign vesting params snapshotted at creation, falling back
     // to the global defaults for campaigns created before the snapshot was
@@ -97,7 +97,7 @@ pub(crate) fn withdraw_funds(env: &Env, campaign_id: u32) -> Result<(), Error> {
     set_total_raised_global(
         env,
         total_raised
-            .checked_sub(campaign.amount_raised - reserve_amount)
+            .checked_sub(campaign.effective_amount_raised - reserve_amount)
             .ok_or(Error::Overflow)?,
     );
 

--- a/src/tests/test_withdrawals.rs
+++ b/src/tests/test_withdrawals.rs
@@ -193,6 +193,7 @@ fn test_withdraw_funds_overflow_returns_error_not_panic() {
     env.as_contract(&client.address, || {
         let mut campaign = storage::get_campaign(&env, campaign_id).unwrap();
         campaign.amount_raised = i128::MAX;
+        campaign.effective_amount_raised = i128::MAX;
         storage::set_campaign(&env, campaign_id, &campaign);
     });
 


### PR DESCRIPTION
Fix withdraw_funds to use effective_amount_raised for fee/reserve calculations instead of amount_raised.

This ensures the withdraw logic correctly accounts for the reserve that was already deducted from effective_amount_raised.

Closes #514