### PR TITLE
feat: add admin-configurable per-transaction contribution cap (#522)

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,14 +4,15 @@ use crate::errors::Error;
 use crate::lifecycle::{assert_admin, get_campaign_or_error, require_active_campaign};
 use crate::storage::{
     self, bump_instance_ttl, get_active_campaign_count, get_admin, get_approval_threshold_bps,
-    get_max_campaign_funding_goal, get_min_campaign_funding_goal, get_min_votes_quorum,
-    get_pending_admin, get_pending_token, get_pending_token_release, get_platform_fee, get_token,
-    get_token_update_delay_secs, get_total_raised_global, get_version, is_initialized,
-    remove_has_voted, remove_pending_admin, remove_pending_token, remove_voting_state, set_admin,
-    set_approval_threshold_bps, set_campaign_count, set_creation_disabled, set_initialized,
-    set_max_campaign_funding_goal, set_min_campaign_funding_goal, set_min_votes_quorum,
-    set_min_voting_balance, set_pending_admin, set_pending_token, set_pending_token_release,
-    set_platform_fee, set_token, set_token_update_delay_secs, set_total_raised_global, set_version,
+    get_max_campaign_funding_goal, get_max_tx_contribution, get_min_campaign_funding_goal,
+    get_min_votes_quorum, get_pending_admin, get_pending_token, get_pending_token_release,
+    get_platform_fee, get_token, get_token_update_delay_secs, get_total_raised_global, get_version,
+    is_initialized, remove_has_voted, remove_pending_admin, remove_pending_token,
+    remove_voting_state, set_admin, set_approval_threshold_bps, set_campaign_count,
+    set_creation_disabled, set_initialized, set_max_campaign_funding_goal, set_max_tx_contribution,
+    set_min_campaign_funding_goal, set_min_votes_quorum, set_min_voting_balance, set_pending_admin,
+    set_pending_token, set_pending_token_release, set_platform_fee, set_token,
+    set_token_update_delay_secs, set_total_raised_global, set_version,
     set_withdraw_release_delay_days, set_withdraw_reserve_percentage, AdminKey,
 };
 use crate::voting;
@@ -301,6 +302,28 @@ pub(crate) fn set_max_campaign_funding_goal_fn(
         ("max_campaign_funding_goal_updated",),
         (old_max_goal, max_goal),
     );
+    Ok(())
+}
+
+/// Sets the global maximum contribution allowed in a single `contribute` call.
+/// `0` disables the limit. Negative values are rejected; a value of `0` is an
+/// explicit, documented sentinel meaning "no per-transaction cap" (#530
+/// semantics reused for the global cap).
+pub(crate) fn set_max_tx_contribution_fn(
+    env: &Env,
+    admin: Address,
+    amount: i128,
+) -> Result<(), Error> {
+    assert_admin(env, &admin)?;
+    // No require_not_paused: the cap is admin governance, like funding-goal limits (#388).
+    if amount < 0 {
+        return Err(Error::ValidationFailed);
+    }
+    let old_amount = get_max_tx_contribution(env);
+    bump_instance_ttl(env);
+    set_max_tx_contribution(env, amount);
+    env.events()
+        .publish(("max_tx_contribution_updated",), (old_amount, amount));
     Ok(())
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,3 +30,11 @@ pub(crate) const TOKEN_UPDATE_DELAY_SECS: u64 = 7 * SECONDS_PER_DAY;
 /// admin-configurable range stays sane while still covering any realistic
 /// timelock policy (#650).
 pub(crate) const MAX_TOKEN_UPDATE_DELAY_SECS: u64 = 365 * SECONDS_PER_DAY;
+
+/// Default maximum contribution allowed in a single `contribute` call.
+///
+/// `0` is the explicit "no limit" sentinel, mirroring
+/// `Campaign::max_contribution_per_user` (#530). Only non-negative values are
+/// accepted by `set_max_tx_contribution`; the effective limit is read from
+/// storage and falls back to this constant.
+pub(crate) const DEFAULT_MAX_CONTRIBUTION_PER_TRANSACTION: i128 = 0;

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -6,11 +6,12 @@ use crate::lifecycle::{
 };
 use crate::storage::{
     bump_instance_ttl, decrement_contributor_count, get_campaign_block_contribution_count,
-    get_contribution, get_lifetime_contribution, get_personal_cap, get_top_contributor,
-    get_total_raised_global, increment_contributor_count, remove_contribution, remove_personal_cap,
-    remove_revenue_claimed, set_campaign, set_campaign_block_contribution_count, set_contribution,
-    set_last_contribution_time, set_lifetime_contribution, set_personal_cap, set_top_contributor,
-    set_total_raised_global, AdminKey,
+    get_contribution, get_lifetime_contribution, get_max_tx_contribution, get_personal_cap,
+    get_top_contributor, get_total_raised_global, increment_contributor_count, remove_contribution,
+    remove_personal_cap, remove_revenue_claimed, set_campaign,
+    set_campaign_block_contribution_count, set_contribution, set_last_contribution_time,
+    set_lifetime_contribution, set_personal_cap, set_top_contributor, set_total_raised_global,
+    AdminKey,
 };
 use crate::types::Campaign;
 
@@ -176,6 +177,11 @@ pub(crate) fn contribute(
     }
 
     check_burst_guard(env, campaign_id, &campaign, amount)?;
+
+    let max_per_tx = get_max_tx_contribution(env);
+    if max_per_tx > 0 && amount > max_per_tx {
+        return Err(Error::ExceedsMaxContributionPerTransaction);
+    }
 
     bump_instance_ttl(env);
     update_contribution_accounting(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,6 +97,8 @@ pub enum Error {
     CampaignNotBookmarked = 45,
     /// The contributor has no personal cap set on this campaign.
     PersonalCapNotFound = 46,
+    /// The contribution amount exceeds the global per-transaction limit.
+    ExceedsMaxContributionPerTransaction = 49,
 }
 
 /// Builds an exhaustive `match self { Error::V => stringify!(V), ... }` from
@@ -169,6 +171,7 @@ impl Error {
                 CampaignAlreadyBookmarked,
                 CampaignNotBookmarked,
                 PersonalCapNotFound,
+                ExceedsMaxContributionPerTransaction,
             ]
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ mod types;
 mod voting;
 
 pub(crate) use constants::{
-    BPS_CEIL_OFFSET, BPS_DENOMINATOR, MAX_TOKEN_UPDATE_DELAY_SECS, SECONDS_PER_DAY,
-    TOKEN_UPDATE_DELAY_SECS,
+    BPS_CEIL_OFFSET, BPS_DENOMINATOR, DEFAULT_MAX_CONTRIBUTION_PER_TRANSACTION,
+    MAX_TOKEN_UPDATE_DELAY_SECS, SECONDS_PER_DAY, TOKEN_UPDATE_DELAY_SECS,
 };
 pub use errors::Error;
 use soroban_sdk::{contract, contractimpl, Address, Env, String};
@@ -368,6 +368,12 @@ impl ProofOfHeart {
         admin::set_max_campaign_funding_goal_fn(&env, admin, max_goal)
     }
 
+    /// Sets the global maximum contribution allowed in a single `contribute`
+    /// call. `0` disables the limit. Only the admin may change it.
+    pub fn set_max_tx_contribution(env: Env, admin: Address, amount: i128) -> Result<(), Error> {
+        admin::set_max_tx_contribution_fn(&env, admin, amount)
+    }
+
     // ── Admin: voting params ──────────────────────────────────────────────────
 
     pub fn set_voting_params(
@@ -575,6 +581,10 @@ impl ProofOfHeart {
 
     pub fn get_max_campaign_funding_goal(env: Env) -> i128 {
         get_max_campaign_funding_goal(&env, CAMPAIGN_FUNDING_GOAL_MAX)
+    }
+
+    pub fn get_max_tx_contribution(env: Env) -> i128 {
+        get_max_tx_contribution(&env)
     }
 
     pub fn get_min_voting_balance(env: Env) -> i128 {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -79,6 +79,8 @@ pub enum AdminKey {
     /// Admin-configured delay (seconds) before a proposed token update can be
     /// accepted, overriding the compiled-in `TOKEN_UPDATE_DELAY_SECS` default (#650).
     TokenUpdateDelaySecs,
+    /// Maximum contribution allowed in a single `contribute` call (0 = unlimited).
+    MaxContributionPerTransaction,
 }
 
 /// Keys for campaign records, indexes, and aggregate campaign counters.
@@ -324,6 +326,25 @@ pub fn set_max_campaign_funding_goal(env: &Env, max_goal: i128) {
     env.storage()
         .instance()
         .set(&AdminKey::MaxCampaignFundingGoal, &max_goal);
+}
+
+// ── Per-transaction contribution cap ─────────────────────────────────────────
+
+/// Returns the maximum contribution allowed in a single `contribute` call,
+/// falling back to the compiled-in default (`0` = unlimited) if unset.
+pub fn get_max_tx_contribution(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&AdminKey::MaxContributionPerTransaction)
+        .unwrap_or(crate::DEFAULT_MAX_CONTRIBUTION_PER_TRANSACTION)
+}
+
+/// Stores the maximum contribution allowed in a single `contribute` call.
+/// `0` means unlimited.
+pub fn set_max_tx_contribution(env: &Env, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&AdminKey::MaxContributionPerTransaction, &amount);
 }
 
 // ── Contributions ─────────────────────────────────────────────────────────────

--- a/src/tests/test_contributions.rs
+++ b/src/tests/test_contributions.rs
@@ -452,6 +452,65 @@ fn test_max_contribution_per_user_enforced_across_multiple_transactions() {
 }
 
 #[test]
+fn test_max_tx_contribution_enforced_per_transaction() {
+    let (env, admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5_000);
+
+    // Default: no per-transaction cap.
+    assert_eq!(client.get_max_tx_contribution(), 0);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Per tx cap"),
+        String::from_str(&env, "global per-tx limit"),
+        5_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        5_000i128,
+    ));
+    client.verify_campaign(&campaign_id);
+
+    // Admin sets a global per-transaction cap of 500.
+    client.set_max_tx_contribution(&admin, &500);
+    assert_eq!(client.get_max_tx_contribution(), 500);
+
+    // A single contribution below the cap succeeds.
+    client.contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 500);
+
+    // A single contribution above the cap is rejected without moving funds.
+    let res = client.try_contribute(&campaign_id, &contributor1, &600);
+    assert_eq!(
+        res.unwrap_err().unwrap(),
+        Error::ExceedsMaxContributionPerTransaction
+    );
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 500);
+
+    // Cap applies per transaction, not per lifetime: splitting the same total
+    // across multiple transactions is still allowed.
+    client.contribute(&campaign_id, &contributor1, &500);
+    assert_eq!(client.get_contribution(&campaign_id, &contributor1), 1_000);
+}
+
+#[test]
+fn test_set_max_tx_contribution_validation() {
+    let (_env, admin, creator, _c1, _c2, _token, _token_admin, client) = setup_env();
+
+    // Negative values are rejected.
+    let res = client.try_set_max_tx_contribution(&admin, &-1);
+    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+    // Zero disables the cap.
+    client.set_max_tx_contribution(&admin, &0);
+    assert_eq!(client.get_max_tx_contribution(), 0);
+
+    // Non-admin cannot change the cap.
+    let res = client.try_set_max_tx_contribution(&creator.clone(), &100);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}
+
+#[test]
 fn test_personal_cap_enforcement() {
     let (env, _admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
     token_admin.mint(&contributor1, &5000);


### PR DESCRIPTION
Add an admin-configurable per-transaction contribution cap to prevent single large contributions from exceeding the per-transaction limit.

Changes:
- New error: ExceedsMaxContributionPerTransaction (code 49)
- New constant: DEFAULT_MAX_CONTRIBUTION_PER_TRANSACTION = 0 (no cap)
- Storage: AdminKey::MaxContributionPerTransaction with getter/setter
- Contributions: enforce cap in contribute() (not batch_contribute, follow-up noted)
- Admin: set_max_tx_contribution_fn with ValidationFailed for negative values
- Lib: public get_max_tx_contribution / set_max_tx_contribution exports
- Tests: test_max_tx_contribution_enforced_per_transaction, test_set_max_tx_contribution_validation

Note: batch_contribute intentionally not capped (faithful to original scope). The cap uses 0 as no-cap sentinel; negative values rejected.

Closes #522