### PR TITLE
ci(#450): pin action versions and sync CONTRIBUTING.md with CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-audit
       - run: cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added a `Makefile` with a `build-docker` target utilizing the `stellar/rs-soroban-sdk` image to guarantee WASM binary reproducibility, allowing anyone to verify that the deployed on-chain bytecode matches the source (#533).
 - Resolved pre-existing CI debt surfaced by the `fmt` and `clippy` gates added in #403: test fixture missing bindings restored in `src/test.rs` and `src/tests/test_init.rs`, `result` double-move fixed in `src/tests/test_admin.rs`, `cargo fmt --all` drift cleared across `src/issues_test.rs` and `src/lib.rs`, and clippy lints addressed (`manual_div_ceil` in `src/lib.rs`; `dead_code` suppressed on deferred storage helpers pending the DataKey audit in #409). All three CI jobs (`test`, `fmt`, `clippy`) now exit 0 on a clean checkout (#418).
+- Pinned GitHub Actions to full commit hashes in `ci.yml` (`audit` job) to prevent supply-chain tampering through mutable version tags (#450).
+- Corrected `CONTRIBUTING.md` "Code Style" section to list the actual five commands running in CI (replaced `stellar contract build` with `cargo build --target wasm32-unknown-unknown --release`, added `--all` to `cargo fmt`, updated the check count from four to five, and documented why `--all` is needed for the vendored `ethnum` crate) (#450).
 
 ### Refactored
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ git remote add upstream https://github.com/Iris-IV/ProofOfHeart-stellar.git
 
 ```bash
 # Build WASM (Local development)
-stellar contract build
+cargo build --target wasm32-unknown-unknown --release
 
 # Build reproducible WASM (Required for production deployment)
 make build-docker
@@ -60,14 +60,14 @@ The repo includes a `rust-toolchain.toml` that pins the Rust toolchain automatic
 CI runs these checks on every PR. Run locally before pushing:
 
 ```bash
-cargo fmt --check
+cargo fmt --all -- --check
 cargo clippy --all-targets --features testutils -- -D warnings
 cargo test --features testutils
-stellar contract build
+cargo build --target wasm32-unknown-unknown --release
 cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009
 ```
 
-All five must pass. `cargo audit` (install with `cargo install cargo-audit`) scans the dependency tree for known security advisories and fails if any apply to a locked version. The two `--ignore` flags are required and mirror the CI gate (see `.github/workflows/ci.yml`); both advisories are documented there:
+All five must pass. The `cargo fmt` invocation uses `--all` to cover the vendored `ethnum` crate alongside the main project. `cargo audit` (install with `cargo install cargo-audit`) scans the dependency tree for known security advisories and fails if any apply to a locked version. The two `--ignore` flags are required and mirror the CI gate (see `.github/workflows/ci.yml`); both advisories are documented there:
 
 - `RUSTSEC-2024-0344` (`curve25519-dalek < 4.1.3`): `soroban-env-host 20.1.0` pins this crate to exactly `4.1.1`, which is in turn fixed by the pinned `soroban-sdk =20.1.0`. The patched version is not installable without upgrading the SDK.
 - `RUSTSEC-2026-0009` (`time < 0.3.47`): `time` only enters the graph as an optional dependency of `serde_with` behind its disabled `time_0_3` feature, so the vulnerable code is never compiled.
@@ -111,7 +111,7 @@ test: deadline boundary coverage
 1. Reference the issue: `Closes #28`
 2. Fill out the PR template (auto-applied from `.github/PULL_REQUEST_TEMPLATE.md`)
 3. Update `EVENT_PAYLOADS.md` if your PR adds, modifies, or removes any `env.events().publish(...)` call — keep topics, data shape, and source location in sync
-4. Ensure CI is green — all four checks in the Code Style section must pass
+4. Ensure CI is green — all five checks in the Code Style section must pass
 5. One issue per PR
 
 ## Changelog


### PR DESCRIPTION
### Summary

Closes #450.

This PR fixes a long-standing discrepancy between the repo's documentation and
the actual CI pipeline. The `.github/workflows/ci.yml` already runs `cargo fmt`,
`cargo clippy`, and `cargo audit` (added in prior PRs #403 and #471), but
`CONTRIBUTING.md` still referenced the outdated `stellar contract build` command
and omitted the `--all` flag on `cargo fmt`. It also claimed only four checks
when there are actually five. Additionally, the `audit` job's GitHub Actions
were referenced by mutable version tags (`@v4`, `@v2`) rather than pinned to
full commit hashes — a supply-chain hardening gap.

### Changes

#### `.github/workflows/ci.yml`
- Pin `actions/checkout@v4` → `actions/checkout@11d5960...` (v4.4.0)
- Pin `taiki-e/install-action@v2` → `taiki-e/install-action@b6ff580...` (v2)

#### `CONTRIBUTING.md`
- Replace `stellar contract build` with `cargo build --target wasm32-unknown-unknown --release` (two instances)
- Replace `cargo fmt --check` with `cargo fmt --all -- --check` to cover the
  vendored `ethnum` crate alongside the main project
- Add explanatory sentence documenting why `--all` is required
- Update "four checks" → "five checks" to match the five listed commands

#### `CHANGELOG.md`
- Add entries under `### Infrastructure` for both the pinned actions and the
  CONTRIBUTING.md corrections

### CI Verification

All five checks from `CONTRIBUTING.md` § Code Style pass cleanly on this branch:

| Check | Result |
|-------|--------|
| `cargo fmt --all -- --check` | ✅ clean |
| `cargo clippy --all-targets --features testutils -- -D warnings` | ✅ no warnings |
| `cargo test --features testutils` | ✅ 438 passed |
| `cargo build --target wasm32-unknown-unknown --release` | ✅ success |
| `cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009` | ✅ clean |

### Background

Issue #450 reported that `CONTRIBUTING.md` and `IMPLEMENTATION_SUMMARY.md`
falsely claimed CI ran `fmt`/`clippy` when they didn't — and that two P0
issues (unreachable return, duplicate discriminant) should have been caught.
Those CI gates were subsequently added (fmt/clippy in #403, audit in #471),
and the P0 bugs were fixed. `IMPLEMENTATION_SUMMARY.md` was already deleted
from `main`. This PR closes the remaining gap: documentation that matches
reality and hardened action references.