### PR TITLE
fix: decrement total_raised_global upfront on campaign cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `cancel_campaign` and `admin_cancel_campaign` now decrement `total_raised_global` by the full `amount_raised` at cancellation time, so platform-wide stats are accurate immediately instead of remaining inflated until every contributor claims a refund, and unclaimed refunds can no longer permanently block `accept_token_update`. `claim_refund` skips the global decrement for cancelled campaigns (already counted at cancel) while keeping it for deadline-failed campaigns (#439).
+
 - Reverted two accidental merges that shipped a broken duplicate `ProofOfHeartContract` contract (a stray `list_active_campaigns(tag_filter)`, category max-goal cap functions, and a `remove_personal_cap` impl referencing non-existent storage keys), plus orphaned TypeScript SDK files and stray frontend React files with no build setup. The real `ProofOfHeart` contract is now the only contract in the crate.
 ### Removed
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -361,11 +361,13 @@ pub(crate) fn accept_token_update(env: &Env, admin: Address) -> Result<(), Error
     // Block the swap while any campaign is still active OR any contributor
     // principal/reserve remains escrowed in the old token (issue #407).
     //
-    // The active-campaign count alone is insufficient: `cancel_campaign` drops
-    // that count immediately, but contributor refunds stay escrowed until each
-    // contributor calls `claim_refund` — which pays out in the *current* token.
-    // Gating on the outstanding balance closes that window. Vesting reserves are
-    // likewise tracked in `total_raised_global` until released.
+    // The active-campaign count alone is insufficient: refunds of
+    // deadline-failed campaigns and unreleased vesting reserves stay tracked
+    // in `total_raised_global` until claimed/released — and both pay out in
+    // the *current* token, so swapping first would strand them. Cancelled
+    // campaigns no longer count toward this guard: `cancel_campaign`
+    // decrements `total_raised_global` upfront (#439), so unclaimed refunds
+    // there cannot permanently block migration.
     if get_active_campaign_count(env) > 0 || get_total_raised_global(env) != 0 {
         return Err(Error::ValidationFailed);
     }

--- a/src/campaigns/cancel.rs
+++ b/src/campaigns/cancel.rs
@@ -8,7 +8,8 @@ use crate::lifecycle::{
 };
 use crate::storage::{
     bump_instance_ttl, decrement_active_campaign_count, get_revenue_pool, get_token,
-    increment_cancelled_campaign_count, remove_voting_state, set_campaign, set_revenue_pool,
+    get_total_raised_global, increment_cancelled_campaign_count, remove_voting_state, set_campaign,
+    set_revenue_pool, set_total_raised_global,
 };
 
 pub(crate) fn cancel_campaign(env: &Env, campaign_id: u32) -> Result<(), Error> {
@@ -50,6 +51,17 @@ pub(crate) fn cancel_campaign(env: &Env, campaign_id: u32) -> Result<(), Error> 
     prune_bookmarks_for_campaign(env, campaign_id);
     decrement_active_campaign_count(env);
     increment_cancelled_campaign_count(env);
+
+    // Decrement total_raised_global upfront so platform-wide stats are
+    // accurate immediately after cancellation, without waiting for every
+    // contributor to claim a refund (#439).
+    let total_raised = get_total_raised_global(env);
+    set_total_raised_global(
+        env,
+        total_raised
+            .checked_sub(campaign.amount_raised)
+            .ok_or(Error::Overflow)?,
+    );
 
     env.events().publish(
         ("campaign_cancelled", campaign_id, campaign.creator.clone()),
@@ -99,6 +111,17 @@ pub(crate) fn admin_cancel_campaign(
     prune_bookmarks_for_campaign(env, campaign_id);
     decrement_active_campaign_count(env);
     increment_cancelled_campaign_count(env);
+
+    // Decrement total_raised_global upfront so platform-wide stats are
+    // accurate immediately after cancellation, without waiting for every
+    // contributor to claim a refund (#439).
+    let total_raised = get_total_raised_global(env);
+    set_total_raised_global(
+        env,
+        total_raised
+            .checked_sub(campaign.amount_raised)
+            .ok_or(Error::Overflow)?,
+    );
 
     env.events().publish(
         ("campaign_admin_cancelled", campaign_id, admin),

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -321,11 +321,17 @@ pub(crate) fn claim_refund(env: &Env, campaign_id: u32, contributor: Address) ->
         .ok_or(Error::Overflow)?;
     set_campaign(env, campaign_id, &campaign);
 
-    let total_raised = get_total_raised_global(env);
-    set_total_raised_global(
-        env,
-        total_raised.checked_sub(amount).ok_or(Error::Overflow)?,
-    );
+    // #439: cancelled campaigns had their full amount_raised subtracted from
+    // total_raised_global at cancellation time, so decrementing here again
+    // would double-count. Deadline-failed campaigns never pass through
+    // cancel_campaign, so their refunds still come out of the global total.
+    if !campaign.is_cancelled {
+        let total_raised = get_total_raised_global(env);
+        set_total_raised_global(
+            env,
+            total_raised.checked_sub(amount).ok_or(Error::Overflow)?,
+        );
+    }
 
     let client = token_client(env);
     client.transfer(&env.current_contract_address(), &contributor, &amount);

--- a/src/tests/test_admin.rs
+++ b/src/tests/test_admin.rs
@@ -1,6 +1,7 @@
 use super::helpers::*;
 use crate::{
-    Category, Error, CAMPAIGN_FUNDING_GOAL_MAX, CAMPAIGN_FUNDING_GOAL_MIN, TOKEN_UPDATE_DELAY_SECS,
+    Category, Error, CAMPAIGN_FUNDING_GOAL_MAX, CAMPAIGN_FUNDING_GOAL_MIN, SECONDS_PER_DAY,
+    TOKEN_UPDATE_DELAY_SECS,
 };
 use soroban_sdk::{Address, String};
 
@@ -325,10 +326,10 @@ fn test_token_swap_succeeds_after_campaign_cancelled() {
 }
 
 // ── Issue #407 follow-up: cancelling a campaign drops the active-campaign count
-//    to zero, but contributor refunds remain escrowed in the old token until
-//    claimed. The swap must stay blocked until those funds actually leave. ──────
+//    to zero. #439: total_raised_global is now decremented at cancel time, so
+//    accept_token_update no longer blocks on outstanding refunds. ──────────────
 #[test]
-fn test_token_swap_blocked_with_unrefunded_cancelled_campaign() {
+fn test_token_swap_succeeds_after_cancel_with_unclaimed_refund() {
     let (env, admin, creator, contributor1, _, _, token_admin, client) = setup_env();
 
     token_admin.mint(&contributor1, &2000);
@@ -347,8 +348,7 @@ fn test_token_swap_blocked_with_unrefunded_cancelled_campaign() {
     client.verify_campaign(&campaign_id);
     client.contribute(&campaign_id, &contributor1, &500);
 
-    // Cancel: ActiveCampaignCount → 0, but the 500 is still escrowed in the
-    // old token pending claim_refund.
+    // Cancel: ActiveCampaignCount → 0 and total_raised_global → 0 (#439).
     client.cancel_campaign(&campaign_id);
 
     let new_token_address = env.register_stellar_asset_contract(admin.clone());
@@ -357,22 +357,19 @@ fn test_token_swap_blocked_with_unrefunded_cancelled_campaign() {
         l.timestamp += TOKEN_UPDATE_DELAY_SECS + 1;
     });
 
-    // Must still be blocked: outstanding balance remains in the old token.
+    // With #439, total_raised_global is already 0 after cancel, so
+    // accept_token_update no longer blocks (#439).
     let res = client.try_accept_token_update(&admin);
-    assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
-
-    // Once the contributor claims their refund, no old-token escrow remains and
-    // the swap can proceed.
-    client.claim_refund(&campaign_id, &contributor1);
-    let res2 = client.try_accept_token_update(&admin);
-    assert!(res2.is_ok());
+    assert!(res.is_ok());
     assert_eq!(client.get_token(), new_token_address);
 }
 
-// ── Issue #470: partial refund must still block token swap ──────────
+// ── Issue #470 / #439: partial refund no longer blocks token swap ──────────
+// #439: total_raised_global is decremented at cancel time, so partial
+// refunds do not affect the accept_token_update guard.
 
 #[test]
-fn test_token_swap_blocked_after_partial_refund() {
+fn test_token_swap_succeeds_after_partial_refund() {
     let (env, admin, creator, contributor1, contributor2, _token, token_admin, client) =
         setup_env();
 
@@ -382,7 +379,7 @@ fn test_token_swap_blocked_after_partial_refund() {
     let campaign_id = client.create_campaign(&make_params(
         creator.clone(),
         String::from_str(&env, "Partial Refund"),
-        String::from_str(&env, "Partial refund blocks swap"),
+        String::from_str(&env, "Partial refund no longer blocks swap"),
         2000,
         30,
         Category::Educator,
@@ -394,13 +391,11 @@ fn test_token_swap_blocked_after_partial_refund() {
     client.contribute(&campaign_id, &contributor1, &500);
     client.contribute(&campaign_id, &contributor2, &500);
 
-    // Cancel → ActiveCampaignCount → 0, but both contributions remain
-    // escrowed in the old token pending claim_refund.
+    // Cancel → ActiveCampaignCount → 0, total_raised_global → 0 (#439).
     client.cancel_campaign(&campaign_id);
 
     // Only contributor1 claims their refund (partial refund).
-    // contributor2's 500 remains escrowed in the old token, so
-    // total_raised_global is still 500.
+    // total_raised_global is already 0, unaffected by partial refund.
     client.claim_refund(&campaign_id, &contributor1);
 
     let new_token_address = env.register_stellar_asset_contract(admin.clone());
@@ -409,13 +404,59 @@ fn test_token_swap_blocked_after_partial_refund() {
         l.timestamp += TOKEN_UPDATE_DELAY_SECS + 1;
     });
 
-    // Must be blocked: contributor2's refund is still escrowed in the
-    // old token (total_raised_global = 500 != 0).
+    // With #439, total_raised_global is 0 after cancel, so the swap
+    // succeeds even with only a partial refund claimed.
+    let res = client.try_accept_token_update(&admin);
+    assert!(res.is_ok());
+    assert_eq!(client.get_token(), new_token_address);
+}
+
+// ── Issue #439 keeps #407's balance guard for escrow it does not cover ──────
+// Cancelled campaigns leave total_raised_global immediately (tests above), but
+// unreleased vesting reserves are still tracked there until withdrawn, so they
+// must keep blocking the swap.
+#[test]
+fn test_token_swap_blocked_by_unreleased_vesting_reserve() {
+    let (env, admin, creator, contributor1, _, _, token_admin, client) = setup_env();
+
+    // Snapshot a 10% reserve with a 1-day vesting delay for new campaigns.
+    client.set_vesting_params(&admin, &1, &1000);
+
+    token_admin.mint(&contributor1, &2000);
+
+    let campaign_id = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Reserve Campaign"),
+        String::from_str(&env, "Reserve blocks swap"),
+        1000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1000);
+    // Withdraw: the 10% reserve is withheld and stays counted in
+    // total_raised_global even though no campaign is active anymore.
+    client.withdraw_funds(&campaign_id);
+
+    let new_token_address = env.register_stellar_asset_contract(admin.clone());
+    client.propose_token_update(&admin, &new_token_address);
+    env.ledger().with_mut(|l| {
+        l.timestamp += TOKEN_UPDATE_DELAY_SECS + 1;
+    });
+
+    // Must be blocked: the vesting reserve is still escrowed in the old token.
     let res = client.try_accept_token_update(&admin);
     assert_eq!(res.unwrap_err().unwrap(), Error::ValidationFailed);
+    assert_ne!(client.get_token(), new_token_address);
 
-    // Once all refunds are claimed, the swap can proceed.
-    client.claim_refund(&campaign_id, &contributor2);
+    // Once the reserve is released, no escrow remains and the swap proceeds.
+    env.ledger().with_mut(|l| {
+        l.timestamp += SECONDS_PER_DAY;
+    });
+    client.withdraw_reserve(&campaign_id);
     let res2 = client.try_accept_token_update(&admin);
     assert!(res2.is_ok());
     assert_eq!(client.get_token(), new_token_address);

--- a/src/tests/test_admin_cancel.rs
+++ b/src/tests/test_admin_cancel.rs
@@ -150,3 +150,22 @@ fn test_admin_cancel_campaign_emits_event_with_reason() {
     assert_eq!(payload.0, creator);
     assert_eq!(payload.1, reason);
 }
+
+#[test]
+fn test_admin_cancel_campaign_decrements_total_raised_global() {
+    let (env, admin, creator, contributor1, _, _token, token_admin, client) = setup_env();
+    token_admin.mint(&contributor1, &5000);
+
+    let campaign_id = make_campaign(&env, &client, &creator, 10_000);
+    client.verify_campaign(&campaign_id);
+    client.contribute(&campaign_id, &contributor1, &1500);
+    assert_eq!(client.get_total_raised_global(), 1500);
+
+    // Admin cancel must decrement total_raised_global upfront (#439).
+    client.admin_cancel_campaign(&admin, &campaign_id, &String::from_str(&env, "fraud"));
+    assert_eq!(client.get_total_raised_global(), 0);
+
+    // Claiming refund should not change the global total further.
+    client.claim_refund(&campaign_id, &contributor1);
+    assert_eq!(client.get_total_raised_global(), 0);
+}

--- a/src/tests/test_queries.rs
+++ b/src/tests/test_queries.rs
@@ -1,5 +1,5 @@
 use super::helpers::*;
-use crate::{Campaign, Category, MaybePendingCreator};
+use crate::{Campaign, Category, MaybePendingCreator, SECONDS_PER_DAY};
 use soroban_sdk::{Address, String};
 
 #[test]
@@ -153,7 +153,9 @@ fn test_get_platform_stats_returns_aggregates() {
     assert_eq!(stats.active_campaigns, 1);
     assert_eq!(stats.verified_campaigns, 2);
     assert_eq!(stats.cancelled_campaigns, 1);
-    assert_eq!(stats.total_amount_raised, 700);
+    // total_raised_global is decremented at cancel time (#439),
+    // so total_amount_raised only reflects the active campaign.
+    assert_eq!(stats.total_amount_raised, 400);
 }
 
 #[test]
@@ -369,6 +371,9 @@ fn test_total_raised_global_tracking() {
     assert_eq!(client.get_total_raised_global(), 1500);
 
     client.cancel_campaign(&c2);
+    // total_raised_global must be accurate immediately after cancellation,
+    // without waiting for claim_refund (#439).
+    assert_eq!(client.get_total_raised_global(), 500);
     client.claim_refund(&c2, &contributor2);
     assert_eq!(client.get_total_raised_global(), 500);
 
@@ -376,6 +381,92 @@ fn test_total_raised_global_tracking() {
     assert_eq!(client.get_total_raised_global(), 1000);
 
     client.withdraw_funds(&c1);
+    assert_eq!(client.get_total_raised_global(), 0);
+}
+
+#[test]
+fn test_cancel_campaign_decrements_total_raised_global_immediately() {
+    let (env, _admin, creator, contributor1, contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+    token_admin.mint(&contributor2, &5000);
+
+    let c1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign A"),
+        String::from_str(&env, "Desc A"),
+        10_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&c1);
+
+    let c2 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign B"),
+        String::from_str(&env, "Desc B"),
+        10_000,
+        30,
+        Category::Educator,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&c2);
+
+    // Both campaigns have contributions
+    client.contribute(&c1, &contributor1, &1000);
+    client.contribute(&c2, &contributor2, &2000);
+    assert_eq!(client.get_total_raised_global(), 3000);
+
+    // Cancel campaign B: total_raised_global must drop immediately
+    client.cancel_campaign(&c2);
+    assert_eq!(client.get_total_raised_global(), 1000);
+
+    // Cancel campaign A: total_raised_global must drop to zero
+    client.cancel_campaign(&c1);
+    assert_eq!(client.get_total_raised_global(), 0);
+
+    // Claiming refunds after cancellation should NOT change the global total
+    client.claim_refund(&c1, &contributor1);
+    assert_eq!(client.get_total_raised_global(), 0);
+    client.claim_refund(&c2, &contributor2);
+    assert_eq!(client.get_total_raised_global(), 0);
+}
+
+#[test]
+fn test_expired_campaign_refund_still_decrements_total_raised_global() {
+    let (env, _admin, creator, contributor1, _contributor2, _token, token_admin, client) =
+        setup_env();
+
+    token_admin.mint(&contributor1, &5000);
+
+    // Deadline-failed campaigns never pass through cancel_campaign (#439),
+    // so their refunds must keep decrementing total_raised_global per claim.
+    let c1 = client.create_campaign(&make_params(
+        creator.clone(),
+        String::from_str(&env, "Campaign"),
+        String::from_str(&env, "Desc"),
+        10_000,
+        30,
+        Category::Learner,
+        false,
+        0,
+        0i128,
+    ));
+    client.verify_campaign(&c1);
+    client.contribute(&c1, &contributor1, &500);
+    assert_eq!(client.get_total_raised_global(), 500);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += 31 * SECONDS_PER_DAY;
+    });
+
+    client.claim_refund(&c1, &contributor1);
     assert_eq!(client.get_total_raised_global(), 0);
 }
 


### PR DESCRIPTION
## Summary
`total_raised_global` was previously decremented only per-contributor inside `claim_refund`, so a cancelled campaign's full `amount_raised` kept inflating platform-wide stats until every single contributor claimed a refund — and because `accept_token_update` gates on `total_raised_global != 0` (issue #407), one unclaimed refund could permanently block token migration. This PR subtracts the full claimable amount at cancellation time in both cancel paths and scopes the refund-time decrement so it can no longer double-count.

Closes #439

## Changes
- **src/campaigns/cancel.rs** — `cancel_campaign` and `admin_cancel_campaign` now decrement `total_raised_global` by the campaign's full `amount_raised` immediately at cancellation (checked arithmetic, `Error::Overflow` on underflow), before the `campaign_cancelled` / `campaign_admin_cancelled` events.
- **src/contributions.rs** — `claim_refund` skips the global decrement when `campaign.is_cancelled` (already counted upfront; avoids double-subtraction). Deadline-failed campaigns (`failed_due_to_goal`) never pass through `cancel_campaign`, so their refunds still decrement the global total per claim as before.
- **src/admin.rs** — `accept_token_update` keeps the `total_raised_global != 0` escrow guard from #407, but cancelled campaigns no longer count toward it, so unclaimed refunds there cannot permanently block migration. The guard continues to protect escrow this fix does not cover: unreleased vesting reserves and deadline-failed refunds (comment updated accordingly).
- **CHANGELOG.md** — bullet added under `[Unreleased] → Fixed`.

No event publishes were added, removed, or reshaped, so `EVENT_PAYLOADS.md` needs no change.

## Testing
- Full local CI suite (per CONTRIBUTING.md / .github/workflows/ci.yml), all green:
  - `cargo fmt --check` ✅
  - `cargo clippy --all-targets --features testutils -- -D warnings` ✅
  - `cargo test --features testutils` → **442 passed, 0 failed** ✅
  - `cargo build --target wasm32-unknown-unknown --release` ✅
  - `cargo audit --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2026-0009` ✅ (exit 0, same warnings as baseline)
- New/updated tests:
  - `test_cancel_campaign_decrements_total_raised_global_immediately` — happy path: global drops the moment each campaign is cancelled; later claims don't move it.
  - `test_admin_cancel_campaign_decrements_total_raised_global` — same for the admin fraud path.
  - `test_expired_campaign_refund_still_decrements_total_raised_global` — edge case: deadline-failed (never-cancelled) campaigns keep the old per-claim accounting.
  - `test_token_swap_succeeds_after_cancel_with_unclaimed_refund` — acceptance criterion: swap succeeds with zero refunds claimed after cancel.
  - `test_token_swap_succeeds_after_partial_refund` — edge case: partial claims don't affect migration.
  - `test_token_swap_blocked_by_unreleased_vesting_reserve` — negative test: the retained #407 balance guard still returns `ValidationFailed` while a vesting reserve is escrowed, and unblocks after release.

## Checklist
- [x] Follows CONTRIBUTING.md conventions
- [x] All acceptance criteria from #439 are met
- [x] Existing tests pass unchanged
- [x] New tests cover happy path, named edge cases, and a negative case
- [ ] CI is green