### PR TITLE
test(fuzz): add voting/lifecycle/revenue fuzz targets, run all targets in CI

### DIFF
--- a/.github/workflows/fuzz.yml.bak
+++ b/.github/workflows/fuzz.yml.bak
@@ -2,6 +2,10 @@ name: Nightly Fuzz
 
 # Issue #506: `contribute()` moves user funds through several validation
 # paths, so it gets a dedicated fuzzing harness (fuzz/fuzz_targets/fuzz_contribute.rs).
+# Issue #770: run every target under fuzz/fuzz_targets/, discovered via
+# `cargo fuzz list`, instead of hardcoding fuzz_contribute -- new targets
+# (voting, lifecycle, revenue, ...) get picked up automatically without a
+# workflow edit.
 # Runs nightly on a time budget rather than on every push/PR, since fuzzing
 # is open-ended and not meant to gate merges.
 on:
@@ -10,19 +14,25 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  fuzz-contribute:
+  fuzz:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # nightly
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
-      - name: Fuzz contribute() for 60 seconds
-        run: cargo fuzz run fuzz_contribute -- -max_total_time=60
+      - name: Fuzz every target for 60 seconds
+        run: |
+          set -euo pipefail
+          for target in $(cargo fuzz list); do
+            echo "::group::fuzz $target"
+            cargo fuzz run "$target" -- -max_total_time=60
+            echo "::endgroup::"
+          done
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fuzz-contribute-crashes
-          path: fuzz/artifacts/fuzz_contribute/
+          name: fuzz-crashes
+          path: fuzz/artifacts/
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Infrastructure
 
+- `fuzz.yml` now discovers fuzz targets via `cargo fuzz list` and runs all of them instead of hardcoding `fuzz_contribute`, so newly added targets are picked up automatically (#770).
 - Added a `fuzz_revenue.rs` fuzz target covering the percentage-based revenue split arithmetic in `revenue.rs`'s deposit/claim paths (#773).
 - Added a `fuzz_lifecycle.rs` fuzz target driving arbitrary sequences of lifecycle-changing calls (contribute, verify, cancel, withdraw) against `lifecycle::transition`'s state-machine guard (#772).
 - Added a `fuzz_voting.rs` fuzz target covering vote-casting and the quorum/approval-threshold arithmetic in `voting.rs` (#771).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Infrastructure
 
+- Added a `fuzz_voting.rs` fuzz target covering vote-casting and the quorum/approval-threshold arithmetic in `voting.rs` (#771).
 - `ci.yml` now caches the cargo registry and `target` directory (`Swatinem/rust-cache`) across the `basic`, `audit`, and `wasm-size` jobs, cutting redundant from-scratch dependency compiles on every run (#762).
 - Restored a `cargo audit` job in `ci.yml`, scanning the dependency tree (including the vendored `ethnum` patch) for known vulnerabilities on every push and PR, with the same `RUSTSEC-2024-0344`/`RUSTSEC-2026-0009` ignores documented in `CONTRIBUTING.md` (#763).
 - Added a `wasm-size` job to `ci.yml` that builds the release WASM target and fails if it grows more than 5% past the recorded baseline in `.github/wasm-size-baseline.txt`, catching unexpected binary bloat before merge (#765).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Infrastructure
 
+- Added a `fuzz_revenue.rs` fuzz target covering the percentage-based revenue split arithmetic in `revenue.rs`'s deposit/claim paths (#773).
 - Added a `fuzz_lifecycle.rs` fuzz target driving arbitrary sequences of lifecycle-changing calls (contribute, verify, cancel, withdraw) against `lifecycle::transition`'s state-machine guard (#772).
 - Added a `fuzz_voting.rs` fuzz target covering vote-casting and the quorum/approval-threshold arithmetic in `voting.rs` (#771).
 - `ci.yml` now caches the cargo registry and `target` directory (`Swatinem/rust-cache`) across the `basic`, `audit`, and `wasm-size` jobs, cutting redundant from-scratch dependency compiles on every run (#762).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Infrastructure
 
+- Added a `fuzz_lifecycle.rs` fuzz target driving arbitrary sequences of lifecycle-changing calls (contribute, verify, cancel, withdraw) against `lifecycle::transition`'s state-machine guard (#772).
 - Added a `fuzz_voting.rs` fuzz target covering vote-casting and the quorum/approval-threshold arithmetic in `voting.rs` (#771).
 - `ci.yml` now caches the cargo registry and `target` directory (`Swatinem/rust-cache`) across the `basic`, `audit`, and `wasm-size` jobs, cutting redundant from-scratch dependency compiles on every run (#762).
 - Restored a `cargo audit` job in `ci.yml`, scanning the dependency tree (including the vendored `ethnum` patch) for known vulnerabilities on every push and PR, with the same `RUSTSEC-2024-0344`/`RUSTSEC-2026-0009` ignores documented in `CONTRIBUTING.md` (#763).

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,10 @@ path = "fuzz_targets/fuzz_contribute.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_voting"
+path = "fuzz_targets/fuzz_voting.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,3 +41,10 @@ path = "fuzz_targets/fuzz_voting.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_lifecycle"
+path = "fuzz_targets/fuzz_lifecycle.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -48,3 +48,10 @@ path = "fuzz_targets/fuzz_lifecycle.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_revenue"
+path = "fuzz_targets/fuzz_revenue.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_lifecycle.rs
+++ b/fuzz/fuzz_targets/fuzz_lifecycle.rs
@@ -1,0 +1,103 @@
+//! Fuzz target for campaign state transitions centralized in `lifecycle.rs`
+//! (issue #772).
+//!
+//! `lifecycle::transition` is the single source of truth for which
+//! `CampaignState` changes are legal (`Active -> Verified`,
+//! `Active/Verified -> Cancelled`, `Verified -> Withdrawn`; `Withdrawn` and
+//! `Cancelled` are terminal). Every lifecycle-changing entry point
+//! (`contribute`, `verify_campaign`, `verify_campaign_with_votes`,
+//! `cancel_campaign`, `withdraw_funds`) consults it before mutating a
+//! campaign. This harness drives a single campaign through an arbitrary
+//! sequence of those calls to catch any path that could apply an invalid
+//! transition or otherwise corrupt state.
+//!
+//! The property under test: no matter the call sequence, every call must
+//! resolve to either `Ok(())` or a typed `Err(Error)` -- in particular
+//! `Error::InvalidStateTransition` for any illegal transition -- and must
+//! never panic / trap the host.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String};
+
+use proof_of_heart::{Category, CreateCampaignParams, ProofOfHeart, ProofOfHeartClient};
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    funding_goal_raw: u32,
+    duration_days_raw: u8,
+    mint_amount: u32,
+    contribute_amount_raw: u32,
+    ops: Vec<u8>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let contributor = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = StellarAssetClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    if client.try_init(&admin, &token_address, &0u32).is_err() {
+        return;
+    }
+
+    let mint_amount = (input.mint_amount as i128).saturating_add(1);
+    token_admin.mint(&contributor, &mint_amount);
+
+    let funding_goal = (input.funding_goal_raw as i128).saturating_add(1) * 1000 + 100_000;
+    let duration_days = (input.duration_days_raw as u64).saturating_add(1).min(365);
+    let contribute_amount = (input.contribute_amount_raw as i128).saturating_add(1);
+
+    let params = CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Fuzz"),
+        description: String::from_str(&env, "Fuzz lifecycle target"),
+        funding_goal,
+        duration_days,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    };
+
+    let campaign_id = match client.try_create_campaign(&params) {
+        Ok(Ok(id)) => id,
+        _ => return,
+    };
+
+    // Drive the campaign through an arbitrary sequence of lifecycle-changing
+    // calls. `lifecycle::transition` must reject any illegal state change
+    // with a typed error rather than letting the campaign land in an
+    // inconsistent state or panicking.
+    for op in input.ops.iter().take(30) {
+        match op % 5 {
+            0 => {
+                let _ = client.try_contribute(&campaign_id, &contributor, &contribute_amount);
+            }
+            1 => {
+                let _ = client.try_verify_campaign(&campaign_id);
+            }
+            2 => {
+                let _ = client.try_verify_campaign_with_votes(&campaign_id);
+            }
+            3 => {
+                let _ = client.try_cancel_campaign(&campaign_id);
+            }
+            _ => {
+                let _ = client.try_withdraw_funds(&campaign_id);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_revenue.rs
+++ b/fuzz/fuzz_targets/fuzz_revenue.rs
@@ -1,0 +1,131 @@
+//! Fuzz target for the percentage-based revenue arithmetic in `revenue.rs`
+//! (issue #773).
+//!
+//! `claim_revenue` and `claim_creator_revenue` split a revenue pool between
+//! contributors (proportional to their contribution) and the creator, using
+//! a chain of `checked_mul`/`checked_div` on `i128` deferred to the last
+//! step to avoid intermediate truncation (#375), plus a last-claimant
+//! dust-sweep to account for per-claim rounding (#526). This harness
+//! fuzzes the contribution amounts (which set the claim denominator), the
+//! revenue-share split, the deposit amounts (which set the pool), and the
+//! claim order/repetition, to catch precision or overflow issues in that
+//! arithmetic.
+//!
+//! The property under test: `deposit_revenue`, `claim_revenue`, and
+//! `claim_creator_revenue` must never panic / trap the host, no matter the
+//! pool size, split, or claim sequence -- each call must always resolve to
+//! either `Ok(())` or a typed `Err(Error)`.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String};
+
+use proof_of_heart::{Category, CreateCampaignParams, ProofOfHeart, ProofOfHeartClient};
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    revenue_share_percentage_raw: u32,
+    num_contributors_raw: u8,
+    contribution_amounts: Vec<u32>,
+    deposit_amounts: Vec<u32>,
+    claim_order: Vec<u8>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = StellarAssetClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    if client.try_init(&admin, &token_address, &0u32).is_err() {
+        return;
+    }
+
+    // Revenue sharing is only allowed for `EducationalStartup` campaigns,
+    // with a share capped at `REVENUE_SHARE_MAX_BPS` (50%); `create_campaign`
+    // rejects anything else, so there's nothing further to fuzz for
+    // out-of-range input.
+    let revenue_share_percentage = (input.revenue_share_percentage_raw % 5000).saturating_add(1);
+
+    let params = CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Fuzz"),
+        description: String::from_str(&env, "Fuzz revenue target"),
+        funding_goal: 100_000,
+        duration_days: 30,
+        category: Category::EducationalStartup,
+        has_revenue_sharing: true,
+        revenue_share_percentage,
+        max_contribution_per_user: 0,
+    };
+
+    let campaign_id = match client.try_create_campaign(&params) {
+        Ok(Ok(id)) => id,
+        _ => return,
+    };
+
+    if client.try_verify_campaign(&campaign_id).is_err() {
+        return;
+    }
+
+    // Fund a handful of contributors and have each contribute an arbitrary
+    // amount, so `effective_amount_raised` (the `claim_revenue` denominator)
+    // ends up an arbitrary value rather than a single round number. Amounts
+    // are kept under the auto-pause single-contribution threshold (200% of
+    // the funding goal) so most sequences reach withdrawal.
+    let num_contributors = (input.num_contributors_raw % 8).saturating_add(1);
+    let mut contributors: Vec<Address> = Vec::new();
+    for i in 0..num_contributors {
+        let contributor = Address::generate(&env);
+        let raw = *input.contribution_amounts.get(i as usize).unwrap_or(&1);
+        let amount = ((raw as i128) % 150_000).saturating_add(1);
+        token_admin.mint(&contributor, &amount);
+        if client
+            .try_contribute(&campaign_id, &contributor, &amount)
+            .is_ok()
+        {
+            contributors.push(contributor);
+        }
+    }
+
+    if client.try_withdraw_funds(&campaign_id).is_err() {
+        return;
+    }
+
+    // Mint the creator enough to cover every deposit, then deposit revenue
+    // in several arbitrary-sized chunks -- claim_revenue/claim_creator_revenue
+    // must never panic regardless of the resulting pool size or split.
+    let deposit_amounts: Vec<i128> = input
+        .deposit_amounts
+        .iter()
+        .take(10)
+        .map(|raw| (*raw as i128).saturating_add(1))
+        .collect();
+    let total_deposits: i128 = deposit_amounts.iter().sum();
+    token_admin.mint(&creator, &total_deposits.max(1));
+    for amount in &deposit_amounts {
+        let _ = client.try_deposit_revenue(&campaign_id, amount);
+    }
+
+    // Claim in an arbitrary order, including repeats, to exercise the
+    // last-claimant dust-sweep path (#526) under randomized sequencing.
+    for &idx in input.claim_order.iter().take(20) {
+        if contributors.is_empty() {
+            break;
+        }
+        let contributor = &contributors[idx as usize % contributors.len()];
+        let _ = client.try_claim_revenue(&campaign_id, contributor);
+    }
+    let _ = client.try_claim_creator_revenue(&campaign_id);
+});

--- a/fuzz/fuzz_targets/fuzz_voting.rs
+++ b/fuzz/fuzz_targets/fuzz_voting.rs
@@ -1,0 +1,113 @@
+//! Fuzz target for vote casting and the threshold/quorum arithmetic in
+//! `voting.rs` (issue #771).
+//!
+//! `cast_vote` and `verify_with_votes` gate campaign verification on
+//! community-configured `min_votes_quorum` and `approval_threshold_bps`
+//! values, then compute an approval percentage from live vote counts. This
+//! harness throws adversarial quorum/threshold configs and vote sequences
+//! (including repeat votes from the same address, and verification attempts
+//! before/after quorum is reached) at those entry points.
+//!
+//! The property under test: none of `set_voting_params`, `cast_vote`, or
+//! `verify_with_votes` must ever panic / trap the host, no matter the
+//! configured quorum, threshold, or vote sequence -- each call must always
+//! resolve to either `Ok(())` or a typed `Err(Error)`.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env, String};
+
+use proof_of_heart::{Category, CreateCampaignParams, ProofOfHeart, ProofOfHeartClient};
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    min_votes_quorum: u32,
+    approval_threshold_bps: u32,
+    min_voting_balance_raw: u32,
+    voter_balance_raw: u32,
+    votes: Vec<bool>,
+    revote_last_voter: bool,
+    verify_with_votes_first: bool,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let token_address = env.register_stellar_asset_contract(admin.clone());
+    let token_admin = StellarAssetClient::new(&env, &token_address);
+
+    let contract_id = env.register_contract(None, ProofOfHeart);
+    let client = ProofOfHeartClient::new(&env, &contract_id);
+
+    if client.try_init(&admin, &token_address, &0u32).is_err() {
+        return;
+    }
+
+    // `set_voting_params` / `set_min_voting_balance` must reject
+    // out-of-range configuration gracefully rather than panicking; when
+    // rejected, the existing defaults simply remain in effect.
+    let _ = client.try_set_voting_params(
+        &admin,
+        &input.min_votes_quorum,
+        &input.approval_threshold_bps,
+    );
+    let min_voting_balance = (input.min_voting_balance_raw as i128) % 1_000_000;
+    let _ = client.try_set_min_voting_balance(&admin, &min_voting_balance);
+
+    let params = CreateCampaignParams {
+        creator: creator.clone(),
+        title: String::from_str(&env, "Fuzz"),
+        description: String::from_str(&env, "Fuzz voting target"),
+        funding_goal: 100_000,
+        duration_days: 30,
+        category: Category::Learner,
+        has_revenue_sharing: false,
+        revenue_share_percentage: 0,
+        max_contribution_per_user: 0,
+    };
+
+    let campaign_id = match client.try_create_campaign(&params) {
+        Ok(Ok(id)) => id,
+        _ => return,
+    };
+
+    // Optionally attempt verification before any votes are cast, exercising
+    // the zero-votes / quorum-not-met path.
+    if input.verify_with_votes_first {
+        let _ = client.try_verify_campaign_with_votes(&campaign_id);
+    }
+
+    // Cast a bounded number of votes from distinct voters, each funded with
+    // the same arbitrary balance, to fuzz the quorum/approval-bps arithmetic
+    // under adversarial approve/reject sequences.
+    let voter_balance = (input.voter_balance_raw as i128).saturating_add(1);
+    let mut last_voter: Option<Address> = None;
+    for &approve in input.votes.iter().take(25) {
+        let voter = Address::generate(&env);
+        token_admin.mint(&voter, &voter_balance);
+        // Must never panic regardless of balance, quorum, or vote history.
+        let _ = client.try_vote_on_campaign(&campaign_id, &voter, &approve);
+        last_voter = Some(voter);
+    }
+
+    // Exercise the `AlreadyVoted` path by having the last voter vote again
+    // with the opposite choice.
+    if input.revote_last_voter {
+        if let Some(voter) = last_voter {
+            let _ = client.try_vote_on_campaign(&campaign_id, &voter, &true);
+        }
+    }
+
+    // Both verification paths must never panic, regardless of how many
+    // votes were cast or how the quorum/threshold params were configured.
+    let _ = client.try_verify_campaign_with_votes(&campaign_id);
+    let _ = client.try_verify_campaign(&campaign_id);
+});


### PR DESCRIPTION
## 📌 Description
Rounds out the fuzz suite beyond `fuzz_contribute.rs` with three new targets — `fuzz_voting.rs`, `fuzz_lifecycle.rs`, and `fuzz_revenue.rs` — and updates the (currently disabled, `fuzz.yml.bak`) nightly fuzz workflow to discover and run every target automatically instead of hardcoding `fuzz_contribute`.

- **`fuzz_voting.rs`** (#771): fuzzes `set_voting_params`, `cast_vote`, and `verify_with_votes` with adversarial quorum/approval-threshold configs and vote sequences (including revotes and premature verification attempts).
- **`fuzz_lifecycle.rs`** (#772): drives a campaign through arbitrary sequences of `contribute` / `verify_campaign` / `verify_campaign_with_votes` / `cancel_campaign` / `withdraw_funds` calls to exercise `lifecycle::transition`'s state-machine guard.
- **`fuzz_revenue.rs`** (#773): fuzzes `revenue_share_percentage`, per-contributor contribution amounts, deposit chunk sizes, and claim order/repetition against `deposit_revenue` / `claim_revenue` / `claim_creator_revenue`, exercising the `checked_mul`/`checked_div` chains and the last-claimant dust-sweep path (#526).
- **`fuzz.yml`** (#770): loops over `cargo fuzz list` instead of a single hardcoded `cargo fuzz run fuzz_contribute`, so the three targets above (and any future ones) run without further workflow edits.

Each new target follows the same shape as the existing `fuzz_contribute.rs`: build a fresh `Env`, drive the target through `ProofOfHeartClient`'s `try_*` entry points with `arbitrary`-derived input, and assert every call resolves to `Ok` or a typed `Err` rather than panicking.

## 🔗 Related Issues
Closes #770
Closes #771
Closes #772
Closes #773

## 🧪 Changes Made
- [x] New feature (test infrastructure)

## ✅ Checklist
- [x] Code compiles successfully — main crate (`cargo test`/`cargo clippy`); fuzz crate could not be locally verified with `cargo-fuzz` in this environment (see note below), but was checked for syntax/API correctness against `ProofOfHeartClient` and matches the existing `fuzz_contribute.rs` pattern
- [x] Tests added/updated and passing — 3 new fuzz targets; `cargo test --features testutils` (438 tests) passes unchanged
- [x] Linting passes (no warnings/errors) — `cargo fmt --check` and `cargo clippy --all-targets --features testutils -- -D warnings` both pass on the main crate; the 3 new fuzz files are `rustfmt`-clean
- [x] Documentation updated (if required) — `CHANGELOG.md` updated under `[Unreleased] / Infrastructure`
- [x] No breaking changes

## ⚠️ Breaking Changes
None — all changes are additive (new fuzz targets, workflow update to `fuzz.yml.bak`), no contract source under `src/` was touched.

## 🧩 Additional Notes
While preparing this PR I could not get `cargo +nightly check` to succeed inside `fuzz/` in my local environment — it fails with `try_size_hint` "not found" errors coming from `stellar-xdr`'s `Arbitrary` derive, on both stable and nightly. I confirmed this is **pre-existing and unrelated to this PR**: stashing all my changes and running the same check against the untouched `fuzz_contribute.rs` on `main` reproduces the identical failure, so it looks like an `arbitrary`-crate version-resolution issue in the dependency graph (no `fuzz/Cargo.lock` is committed) rather than anything introduced here. Flagging it in case it's already known, since it'll also affect building the pre-existing `fuzz_contribute.rs` target.
